### PR TITLE
Enhances size output

### DIFF
--- a/differs/aptDiff.go
+++ b/differs/aptDiff.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/container-diff/utils"
@@ -81,7 +82,15 @@ func parseLine(text string, currPackage string, packages map[string]utils.Packag
 			if !ok {
 				currPackageInfo = utils.PackageInfo{}
 			}
-			currPackageInfo.Size = value
+			var size int64
+			var err error
+			size, err = strconv.ParseInt(value, 10, 64)
+			if err != nil {
+				glog.Errorf("Could not get size for %s: %s", currPackage, err)
+				size = -1
+			}
+			// Installed-Size is in KB, so we convert it to bytes to keep consistent with the tool's size units
+			currPackageInfo.Size = size * 1024 
 			packages[currPackage] = currPackageInfo
 			return currPackage
 		default:

--- a/differs/aptDiff.go
+++ b/differs/aptDiff.go
@@ -90,7 +90,7 @@ func parseLine(text string, currPackage string, packages map[string]utils.Packag
 				size = -1
 			}
 			// Installed-Size is in KB, so we convert it to bytes to keep consistent with the tool's size units
-			currPackageInfo.Size = size * 1024 
+			currPackageInfo.Size = size * 1024
 			packages[currPackage] = currPackageInfo
 			return currPackage
 		default:

--- a/differs/aptDiff_test.go
+++ b/differs/aptDiff_test.go
@@ -49,19 +49,19 @@ func TestParseLine(t *testing.T) {
 		},
 		{
 			descrip:     "Size line",
-			line:        "Installed-Size: 12floz",
+			line:        "Installed-Size: 12",
 			packages:    map[string]utils.PackageInfo{},
 			currPackage: "La-Croix",
 			expPackage:  "La-Croix",
-			expected:    map[string]utils.PackageInfo{"La-Croix": {Size: "12floz"}},
+			expected:    map[string]utils.PackageInfo{"La-Croix": {Size: 12288}},
 		},
 		{
 			descrip:     "Pre-existing PackageInfo struct",
-			line:        "Installed-Size: 12floz",
+			line:        "Installed-Size: 12",
 			packages:    map[string]utils.PackageInfo{"La-Croix": {Version: "Lime"}},
 			currPackage: "La-Croix",
 			expPackage:  "La-Croix",
-			expected:    map[string]utils.PackageInfo{"La-Croix": {Version: "Lime", Size: "12floz"}},
+			expected:    map[string]utils.PackageInfo{"La-Croix": {Version: "Lime", Size: 12288}},
 		},
 	}
 

--- a/differs/nodeDiff.go
+++ b/differs/nodeDiff.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/container-diff/utils"
@@ -55,8 +54,7 @@ func (a NodeAnalyzer) getPackages(image utils.Image) (map[string]map[string]util
 			var currInfo utils.PackageInfo
 			currInfo.Version = packageJSON.Version
 			packagePath := strings.TrimSuffix(currPackage, "package.json")
-			size := utils.GetSize(packagePath)
-			currInfo.Size = strconv.FormatInt(size, 10)
+			currInfo.Size = utils.GetSize(packagePath)
 			mapPath := strings.Replace(packagePath, path, "", 1)
 			// Check if other package version already recorded
 			if _, ok := packages[packageJSON.Name]; !ok {

--- a/differs/nodeDiff_test.go
+++ b/differs/nodeDiff_test.go
@@ -29,17 +29,17 @@ func TestGetNodePackages(t *testing.T) {
 			descrip: "all packages in one layer",
 			path:    "testDirs/packageOne",
 			expected: map[string]map[string]utils.PackageInfo{
-				"pac1": {"/node_modules/pac1/": {Version: "1.0", Size: "41"}},
-				"pac2": {"/usr/local/lib/node_modules/pac2/": {Version: "2.0", Size: "41"}},
-				"pac3": {"/node_modules/pac3/": {Version: "3.0", Size: "41"}}},
+				"pac1": {"/node_modules/pac1/": {Version: "1.0", Size: 41}},
+				"pac2": {"/usr/local/lib/node_modules/pac2/": {Version: "2.0", Size: 41}},
+				"pac3": {"/node_modules/pac3/": {Version: "3.0", Size: 41}}},
 		},
 		{
 			descrip: "Multi version packages",
 			path:    "testDirs/packageMulti",
 			expected: map[string]map[string]utils.PackageInfo{
-				"pac1": {"/node_modules/pac1/": {Version: "1.0", Size: "41"}},
-				"pac2": {"/node_modules/pac2/": {Version: "2.0", Size: "41"},
-					"/usr/local/lib/node_modules/pac2/": {Version: "3.0", Size: "41"}}},
+				"pac1": {"/node_modules/pac1/": {Version: "1.0", Size: 41}},
+				"pac2": {"/node_modules/pac2/": {Version: "2.0", Size: 41},
+					"/usr/local/lib/node_modules/pac2/": {Version: "3.0", Size: 41}}},
 		},
 	}
 

--- a/differs/pipDiff.go
+++ b/differs/pipDiff.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/container-diff/utils"
@@ -66,13 +65,12 @@ func (a PipAnalyzer) getPackages(image utils.Image) (map[string]map[string]utils
 
 				// Retrieves size for actual package/script corresponding to each dist-info metadata directory
 				// by taking the file entry alphabetically before it (for a package) or after it (for a script)
-				var size string
+				var size int64
 				if i-1 >= 0 && contents[i-1].Name() == packageName {
 					packagePath := filepath.Join(pythonPath, packageName)
-					intSize := utils.GetSize(packagePath)
-					size = strconv.FormatInt(intSize, 10)
+					size = utils.GetSize(packagePath)
 				} else if i+1 < len(contents) && contents[i+1].Name() == packageName+".py" {
-					size = strconv.FormatInt(contents[i+1].Size(), 10)
+					size = contents[i+1].Size()
 
 				} else {
 					glog.Errorf("Could not find Python package %s for corresponding metadata info", packageName)

--- a/differs/pipDiff_test.go
+++ b/differs/pipDiff_test.go
@@ -78,13 +78,13 @@ func TestGetPythonPackages(t *testing.T) {
 			},
 			expectedPackages: map[string]map[string]utils.PackageInfo{
 				"packageone": {
-					"/usr/local/lib/python3.6/site-packages": {Version: "3.6.9", Size: "0"},
-					"/usr/local/lib/python2.7/site-packages": {Version: "0.1.1", Size: "0"},
+					"/usr/local/lib/python3.6/site-packages": {Version: "3.6.9", Size: 0},
+					"/usr/local/lib/python2.7/site-packages": {Version: "0.1.1", Size: 0},
 				},
-				"packagetwo": {"/usr/local/lib/python3.6/site-packages": {Version: "4.6.2", Size: "0"}},
-				"script1":    {"/usr/local/lib/python3.6/site-packages": {Version: "1.0", Size: "0"}},
-				"script2":    {"/usr/local/lib/python3.6/site-packages": {Version: "2.0", Size: "0"}},
-				"script3":    {"/usr/local/lib/python2.7/site-packages": {Version: "3.0", Size: "0"}},
+				"packagetwo": {"/usr/local/lib/python3.6/site-packages": {Version: "4.6.2", Size: 0}},
+				"script1":    {"/usr/local/lib/python3.6/site-packages": {Version: "1.0", Size: 0}},
+				"script2":    {"/usr/local/lib/python3.6/site-packages": {Version: "2.0", Size: 0}},
+				"script3":    {"/usr/local/lib/python2.7/site-packages": {Version: "3.0", Size: 0}},
 			},
 		},
 		{
@@ -93,10 +93,10 @@ func TestGetPythonPackages(t *testing.T) {
 				FSPath: "testDirs/pipTests/packagesSingleVersion",
 			},
 			expectedPackages: map[string]map[string]utils.PackageInfo{
-				"packageone": {"/usr/local/lib/python3.6/site-packages": {Version: "3.6.9", Size: "0"}},
-				"packagetwo": {"/usr/local/lib/python3.6/site-packages": {Version: "4.6.2", Size: "0"}},
-				"script1":    {"/usr/local/lib/python3.6/site-packages": {Version: "1.0", Size: "0"}},
-				"script2":    {"/usr/local/lib/python3.6/site-packages": {Version: "2.0", Size: "0"}},
+				"packageone": {"/usr/local/lib/python3.6/site-packages": {Version: "3.6.9", Size: 0}},
+				"packagetwo": {"/usr/local/lib/python3.6/site-packages": {Version: "4.6.2", Size: 0}},
+				"script1":    {"/usr/local/lib/python3.6/site-packages": {Version: "1.0", Size: 0}},
+				"script2":    {"/usr/local/lib/python3.6/site-packages": {Version: "2.0", Size: 0}},
 			},
 		},
 		{
@@ -110,11 +110,11 @@ func TestGetPythonPackages(t *testing.T) {
 				},
 			},
 			expectedPackages: map[string]map[string]utils.PackageInfo{
-				"packageone":   {"/usr/local/lib/python3.6/site-packages": {Version: "3.6.9", Size: "0"}},
-				"packagetwo":   {"/usr/local/lib/python3.6/site-packages": {Version: "4.6.2", Size: "0"}},
-				"packagefive":  {"/pythonPath2/subdir": {Version: "3.6.9", Size: "0"}},
-				"packagesix":   {"/pythonPath1": {Version: "3.6.9", Size: "0"}},
-				"packageseven": {"/pythonPath1": {Version: "4.6.2", Size: "0"}},
+				"packageone":   {"/usr/local/lib/python3.6/site-packages": {Version: "3.6.9", Size: 0}},
+				"packagetwo":   {"/usr/local/lib/python3.6/site-packages": {Version: "4.6.2", Size: 0}},
+				"packagefive":  {"/pythonPath2/subdir": {Version: "3.6.9", Size: 0}},
+				"packagesix":   {"/pythonPath1": {Version: "3.6.9", Size: 0}},
+				"packageseven": {"/pythonPath1": {Version: "4.6.2", Size: 0}},
 			},
 		},
 		{
@@ -128,8 +128,8 @@ func TestGetPythonPackages(t *testing.T) {
 				},
 			},
 			expectedPackages: map[string]map[string]utils.PackageInfo{
-				"packageone": {"/usr/local/lib/python3.6/site-packages": {Version: "3.6.9", Size: "0"}},
-				"packagetwo": {"/usr/local/lib/python3.6/site-packages": {Version: "4.6.2", Size: "0"}},
+				"packageone": {"/usr/local/lib/python3.6/site-packages": {Version: "3.6.9", Size: 0}},
+				"packagetwo": {"/usr/local/lib/python3.6/site-packages": {Version: "4.6.2", Size: 0}},
 			},
 		},
 	}

--- a/tests/apt_analysis_expected.json
+++ b/tests/apt_analysis_expected.json
@@ -5,403 +5,403 @@
     "Analysis": {
       "adduser": {
         "Version": "3.115",
-        "Size": "849"
+        "Size": 869376
       },
       "apt": {
         "Version": "1.4.6",
-        "Size": "3538"
+        "Size": 3622912
       },
       "base-files": {
         "Version": "9.9",
-        "Size": "333"
+        "Size": 340992
       },
       "base-passwd": {
         "Version": "3.5.43",
-        "Size": "229"
+        "Size": 234496
       },
       "bash": {
         "Version": "4.4-5",
-        "Size": "5798"
+        "Size": 5937152
       },
       "bsdutils": {
         "Version": "1:2.29.2-1",
-        "Size": "238"
+        "Size": 243712
       },
       "bzip2": {
         "Version": "1.0.6-8.1",
-        "Size": "184"
+        "Size": 188416
       },
       "coreutils": {
         "Version": "8.26-3",
-        "Size": "15103"
+        "Size": 15465472
       },
       "dash": {
         "Version": "0.5.8-2.4",
-        "Size": "204"
+        "Size": 208896
       },
       "debconf": {
         "Version": "1.5.61",
-        "Size": "558"
+        "Size": 571392
       },
       "debian-archive-keyring": {
         "Version": "2017.5",
-        "Size": "118"
+        "Size": 120832
       },
       "debianutils": {
         "Version": "4.8.1.1",
-        "Size": "213"
+        "Size": 218112
       },
       "diffutils": {
         "Version": "1:3.5-3",
-        "Size": "1327"
+        "Size": 1358848
       },
       "dpkg": {
         "Version": "1.18.24",
-        "Size": "6745"
+        "Size": 6906880
       },
       "e2fslibs": {
         "Version": "1.43.4-2",
-        "Size": "449"
+        "Size": 459776
       },
       "e2fsprogs": {
         "Version": "1.43.4-2",
-        "Size": "4022"
+        "Size": 4118528
       },
       "file": {
         "Version": "1:5.30-1",
-        "Size": "96"
+        "Size": 98304
       },
       "findutils": {
         "Version": "4.6.0 git+20161106-2",
-        "Size": "1854"
+        "Size": 1898496
       },
       "gcc-6-base": {
         "Version": "6.3.0-18",
-        "Size": "209"
+        "Size": 214016
       },
       "gpgv": {
         "Version": "2.1.18-6",
-        "Size": "721"
+        "Size": 738304
       },
       "grep": {
         "Version": "2.27-2",
-        "Size": "1131"
+        "Size": 1158144
       },
       "gzip": {
         "Version": "1.6-5 b1",
-        "Size": "231"
+        "Size": 236544
       },
       "hostname": {
         "Version": "3.18 b1",
-        "Size": "47"
+        "Size": 48128
       },
       "inetutils-ping": {
         "Version": "2:1.9.4-2 b1",
-        "Size": "337"
+        "Size": 345088
       },
       "init-system-helpers": {
         "Version": "1.48",
-        "Size": "131"
+        "Size": 134144
       },
       "iproute2": {
         "Version": "4.9.0-1",
-        "Size": "1753"
+        "Size": 1795072
       },
       "libacl1": {
         "Version": "2.2.52-3 b1",
-        "Size": "62"
+        "Size": 63488
       },
       "libapt-pkg5.0": {
         "Version": "1.4.6",
-        "Size": "3055"
+        "Size": 3128320
       },
       "libattr1": {
         "Version": "1:2.4.47-2 b2",
-        "Size": "42"
+        "Size": 43008
       },
       "libaudit-common": {
         "Version": "1:2.6.7-2",
-        "Size": "30"
+        "Size": 30720
       },
       "libaudit1": {
         "Version": "1:2.6.7-2",
-        "Size": "150"
+        "Size": 153600
       },
       "libblkid1": {
         "Version": "2.29.2-1",
-        "Size": "367"
+        "Size": 375808
       },
       "libbz2-1.0": {
         "Version": "1.0.6-8.1",
-        "Size": "96"
+        "Size": 98304
       },
       "libc-bin": {
         "Version": "2.24-11 deb9u1",
-        "Size": "3365"
+        "Size": 3445760
       },
       "libc6": {
         "Version": "2.24-11 deb9u1",
-        "Size": "10684"
+        "Size": 10940416
       },
       "libcap-ng0": {
         "Version": "0.7.7-3 b1",
-        "Size": "43"
+        "Size": 44032
       },
       "libcomerr2": {
         "Version": "1.43.4-2",
-        "Size": "83"
+        "Size": 84992
       },
       "libdb5.3": {
         "Version": "5.3.28-12 b1",
-        "Size": "1815"
+        "Size": 1858560
       },
       "libdebconfclient0": {
         "Version": "0.227",
-        "Size": "67"
+        "Size": 68608
       },
       "libelf1": {
         "Version": "0.168-1",
-        "Size": "934"
+        "Size": 956416
       },
       "libexpat1": {
         "Version": "2.2.0-2 deb9u1",
-        "Size": "369"
+        "Size": 377856
       },
       "libfdisk1": {
         "Version": "2.29.2-1",
-        "Size": "469"
+        "Size": 480256
       },
       "libffi6": {
         "Version": "3.2.1-6",
-        "Size": "56"
+        "Size": 57344
       },
       "libgcc1": {
         "Version": "1:6.3.0-18",
-        "Size": "108"
+        "Size": 110592
       },
       "libgcrypt20": {
         "Version": "1.7.6-2",
-        "Size": "1262"
+        "Size": 1292288
       },
       "libgpg-error0": {
         "Version": "1.26-2",
-        "Size": "572"
+        "Size": 585728
       },
       "liblz4-1": {
         "Version": "0.0~r131-2 b1",
-        "Size": "93"
+        "Size": 95232
       },
       "liblzma5": {
         "Version": "5.2.2-1.2 b1",
-        "Size": "339"
+        "Size": 347136
       },
       "libmagic-mgc": {
         "Version": "1:5.30-1",
-        "Size": "4832"
+        "Size": 4947968
       },
       "libmagic1": {
         "Version": "1:5.30-1",
-        "Size": "214"
+        "Size": 219136
       },
       "libmnl0": {
         "Version": "1.0.4-2",
-        "Size": "46"
+        "Size": 47104
       },
       "libmount1": {
         "Version": "2.29.2-1",
-        "Size": "403"
+        "Size": 412672
       },
       "libncursesw5": {
         "Version": "6.0 20161126-1",
-        "Size": "347"
+        "Size": 355328
       },
       "libpam-modules": {
         "Version": "1.1.8-3.6",
-        "Size": "874"
+        "Size": 894976
       },
       "libpam-modules-bin": {
         "Version": "1.1.8-3.6",
-        "Size": "220"
+        "Size": 225280
       },
       "libpam-runtime": {
         "Version": "1.1.8-3.6",
-        "Size": "1016"
+        "Size": 1040384
       },
       "libpam0g": {
         "Version": "1.1.8-3.6",
-        "Size": "229"
+        "Size": 234496
       },
       "libpcre3": {
         "Version": "2:8.39-3",
-        "Size": "668"
+        "Size": 684032
       },
       "libpython-stdlib": {
         "Version": "2.7.13-2",
-        "Size": "37"
+        "Size": 37888
       },
       "libpython2.7-minimal": {
         "Version": "2.7.13-2",
-        "Size": "2767"
+        "Size": 2833408
       },
       "libpython2.7-stdlib": {
         "Version": "2.7.13-2",
-        "Size": "8550"
+        "Size": 8755200
       },
       "libreadline7": {
         "Version": "7.0-3",
-        "Size": "416"
+        "Size": 425984
       },
       "libselinux1": {
         "Version": "2.6-3 b1",
-        "Size": "209"
+        "Size": 214016
       },
       "libsemanage-common": {
         "Version": "2.6-2",
-        "Size": "39"
+        "Size": 39936
       },
       "libsemanage1": {
         "Version": "2.6-2",
-        "Size": "291"
+        "Size": 297984
       },
       "libsepol1": {
         "Version": "2.6-2",
-        "Size": "653"
+        "Size": 668672
       },
       "libsmartcols1": {
         "Version": "2.29.2-1",
-        "Size": "257"
+        "Size": 263168
       },
       "libsqlite3-0": {
         "Version": "3.16.2-5",
-        "Size": "1162"
+        "Size": 1189888
       },
       "libss2": {
         "Version": "1.43.4-2",
-        "Size": "95"
+        "Size": 97280
       },
       "libssl1.1": {
         "Version": "1.1.0f-3",
-        "Size": "3524"
+        "Size": 3608576
       },
       "libstdc++6": {
         "Version": "6.3.0-18",
-        "Size": "1998"
+        "Size": 2045952
       },
       "libsystemd0": {
         "Version": "232-25",
-        "Size": "652"
+        "Size": 667648
       },
       "libtinfo5": {
         "Version": "6.0 20161126-1",
-        "Size": "478"
+        "Size": 489472
       },
       "libudev1": {
         "Version": "232-25",
-        "Size": "222"
+        "Size": 227328
       },
       "libustr-1.0-1": {
         "Version": "1.0.4-6",
-        "Size": "258"
+        "Size": 264192
       },
       "libuuid1": {
         "Version": "2.29.2-1",
-        "Size": "107"
+        "Size": 109568
       },
       "login": {
         "Version": "1:4.4-4.1",
-        "Size": "2747"
+        "Size": 2812928
       },
       "lsb-base": {
         "Version": "9.20161125",
-        "Size": "49"
+        "Size": 50176
       },
       "mawk": {
         "Version": "1.3.3-17 b3",
-        "Size": "183"
+        "Size": 187392
       },
       "mime-support": {
         "Version": "3.60",
-        "Size": "110"
+        "Size": 112640
       },
       "mount": {
         "Version": "2.29.2-1",
-        "Size": "444"
+        "Size": 454656
       },
       "multiarch-support": {
         "Version": "2.24-11 deb9u1",
-        "Size": "220"
+        "Size": 225280
       },
       "ncurses-base": {
         "Version": "6.0 20161126-1",
-        "Size": "340"
+        "Size": 348160
       },
       "ncurses-bin": {
         "Version": "6.0 20161126-1",
-        "Size": "532"
+        "Size": 544768
       },
       "netbase": {
         "Version": "5.4",
-        "Size": "44"
+        "Size": 45056
       },
       "passwd": {
         "Version": "1:4.4-4.1",
-        "Size": "2478"
+        "Size": 2537472
       },
       "perl-base": {
         "Version": "5.24.1-3",
-        "Size": "7539"
+        "Size": 7719936
       },
       "python": {
         "Version": "2.7.13-2",
-        "Size": "648"
+        "Size": 663552
       },
       "python-minimal": {
         "Version": "2.7.13-2",
-        "Size": "145"
+        "Size": 148480
       },
       "python2.7": {
         "Version": "2.7.13-2",
-        "Size": "359"
+        "Size": 367616
       },
       "python2.7-minimal": {
         "Version": "2.7.13-2",
-        "Size": "3820"
+        "Size": 3911680
       },
       "readline-common": {
         "Version": "7.0-3",
-        "Size": "89"
+        "Size": 91136
       },
       "sed": {
         "Version": "4.4-1",
-        "Size": "799"
+        "Size": 818176
       },
       "sensible-utils": {
         "Version": "0.0.9",
-        "Size": "110"
+        "Size": 112640
       },
       "sysvinit-utils": {
         "Version": "2.88dsf-59.9",
-        "Size": "110"
+        "Size": 112640
       },
       "tar": {
         "Version": "1.29b-1.1",
-        "Size": "2770"
+        "Size": 2836480
       },
       "tzdata": {
         "Version": "2017b-1",
-        "Size": "3010"
+        "Size": 3082240
       },
       "util-linux": {
         "Version": "2.29.2-1",
-        "Size": "3558"
+        "Size": 3643392
       },
       "xz-utils": {
         "Version": "5.2.2-1.2 b1",
-        "Size": "516"
+        "Size": 528384
       },
       "zlib1g": {
         "Version": "1:1.2.8.dfsg-5",
-        "Size": "156"
+        "Size": 159744
       }
     }
   }

--- a/tests/apt_diff_expected.json
+++ b/tests/apt_diff_expected.json
@@ -7,73 +7,73 @@
       "Packages1": {
         "dh-python": {
           "Version": "2.20170125",
-          "Size": "402"
+          "Size": 411648
         },
         "libmpdec2": {
           "Version": "2.4.2-1",
-          "Size": "254"
+          "Size": 260096
         },
         "libpython3-stdlib": {
           "Version": "3.5.3-1",
-          "Size": "36"
+          "Size": 36864
         },
         "libpython3.5-minimal": {
           "Version": "3.5.3-1",
-          "Size": "3747"
+          "Size": 3836928
         },
         "libpython3.5-stdlib": {
           "Version": "3.5.3-1",
-          "Size": "9896"
+          "Size": 10133504
         },
         "python3": {
           "Version": "3.5.3-1",
-          "Size": "67"
+          "Size": 68608
         },
         "python3-minimal": {
           "Version": "3.5.3-1",
-          "Size": "120"
+          "Size": 122880
         },
         "python3.5": {
           "Version": "3.5.3-1",
-          "Size": "319"
+          "Size": 326656
         },
         "python3.5-minimal": {
           "Version": "3.5.3-1",
-          "Size": "9411"
+          "Size": 9636864
         }
       },
       "Packages2": {
         "libffi6": {
           "Version": "3.2.1-6",
-          "Size": "56"
+          "Size": 57344
         },
         "libpython-stdlib": {
           "Version": "2.7.13-2",
-          "Size": "37"
+          "Size": 37888
         },
         "libpython2.7-minimal": {
           "Version": "2.7.13-2",
-          "Size": "2767"
+          "Size": 2833408
         },
         "libpython2.7-stdlib": {
           "Version": "2.7.13-2",
-          "Size": "8550"
+          "Size": 8755200
         },
         "python": {
           "Version": "2.7.13-2",
-          "Size": "648"
+          "Size": 663552
         },
         "python-minimal": {
           "Version": "2.7.13-2",
-          "Size": "145"
+          "Size": 148480
         },
         "python2.7": {
           "Version": "2.7.13-2",
-          "Size": "359"
+          "Size": 367616
         },
         "python2.7-minimal": {
           "Version": "2.7.13-2",
-          "Size": "3820"
+          "Size": 3911680
         }
       },
       "InfoDiff": []

--- a/tests/multi_diff_expected.json
+++ b/tests/multi_diff_expected.json
@@ -1,152 +1,152 @@
 [
-    {
-        "Image2": "gcr.io/gcp-runtimes/multi-modified", 
-        "Image1": "gcr.io/gcp-runtimes/multi-base", 
-        "DiffType": "Apt", 
-        "Diff": {
-            "Packages1": {}, 
-            "Packages2": {
-                "libmpdec2": {
-                    "Version": "2.4.1-1", 
-                    "Size": "275"
-                }, 
-                "python3.4-minimal": {
-                    "Version": "3.4.2-1", 
-                    "Size": "4506"
-                }, 
-                "libpython3-stdlib": {
-                    "Version": "3.4.2-2", 
-                    "Size": "28"
-                }, 
-                "python3-minimal": {
-                    "Version": "3.4.2-2", 
-                    "Size": "96"
-                }, 
-                "python3.4": {
-                    "Version": "3.4.2-1", 
-                    "Size": "336"
-                }, 
-                "dh-python": {
-                    "Version": "1.20141111-2", 
-                    "Size": "277"
-                }, 
-                "libpython3.4-minimal": {
-                    "Version": "3.4.2-1", 
-                    "Size": "3310"
-                }, 
-                "libpython3.4-stdlib": {
-                    "Version": "3.4.2-1", 
-                    "Size": "9484"
-                }, 
-                "python3": {
-                    "Version": "3.4.2-2", 
-                    "Size": "36"
-                }
-            }, 
-            "InfoDiff": []
+  {
+    "Image1": "gcr.io/gcp-runtimes/multi-base",
+    "Image2": "gcr.io/gcp-runtimes/multi-modified",
+    "DiffType": "Apt",
+    "Diff": {
+      "Packages1": {},
+      "Packages2": {
+        "dh-python": {
+          "Version": "1.20141111-2",
+          "Size": 283648
+        },
+        "libmpdec2": {
+          "Version": "2.4.1-1",
+          "Size": 281600
+        },
+        "libpython3-stdlib": {
+          "Version": "3.4.2-2",
+          "Size": 28672
+        },
+        "libpython3.4-minimal": {
+          "Version": "3.4.2-1",
+          "Size": 3389440
+        },
+        "libpython3.4-stdlib": {
+          "Version": "3.4.2-1",
+          "Size": 9711616
+        },
+        "python3": {
+          "Version": "3.4.2-2",
+          "Size": 36864
+        },
+        "python3-minimal": {
+          "Version": "3.4.2-2",
+          "Size": 98304
+        },
+        "python3.4": {
+          "Version": "3.4.2-1",
+          "Size": 344064
+        },
+        "python3.4-minimal": {
+          "Version": "3.4.2-1",
+          "Size": 4614144
         }
-    }, 
-    {
-        "Image2": "gcr.io/gcp-runtimes/multi-modified", 
-        "Image1": "gcr.io/gcp-runtimes/multi-base", 
-        "DiffType": "Node", 
-        "Diff": {
-            "Packages1": {}, 
-            "Packages2": {
-                "pax": {
-                    "/node_modules/pax/": {
-                        "Version": "0.2.1", 
-                        "Size": "11998"
-                    }
-                }
-            }, 
-            "InfoDiff": [
-                {
-                    "Info1": [
-                        {
-                            "Version": "1.2.4", 
-                            "Size": "56382"
-                        }
-                    ], 
-                    "Info2": [
-                        {
-                            "Version": "0.1.1", 
-                            "Size": "127107"
-                        }
-                    ], 
-                    "Package": "sax"
-                }
-            ]
-        }
-    }, 
-    {
-        "Image2": "gcr.io/gcp-runtimes/multi-modified", 
-        "Image1": "gcr.io/gcp-runtimes/multi-base", 
-        "DiffType": "Pip", 
-        "Diff": {
-            "Packages1": {
-                "pbr": {
-                    "/usr/local/lib/python3.6/site-packages": {
-                        "Version": "3.1.1", 
-                        "Size": "447110"
-                    }
-                }
-            }, 
-            "Packages2": {
-                "retrying": {
-                    "/usr/local/lib/python3.6/site-packages": {
-                        "Version": "1.3.3", 
-                        "Size": "9955"
-                    }
-                }
-            }, 
-            "InfoDiff": [
-                {
-                    "Info1": [
-                        {
-                            "Version": "36.2.2", 
-                            "Size": "839895"
-                        }
-                    ], 
-                    "Info2": [
-                        {
-                            "Version": "36.2.2", 
-                            "Size": "1157078"
-                        }
-                    ], 
-                    "Package": "setuptools"
-                }, 
-                {
-                    "Info1": [
-                        {
-                            "Version": "0.29.0", 
-                            "Size": "103509"
-                        }
-                    ], 
-                    "Info2": [
-                        {
-                            "Version": "0.29.0", 
-                            "Size": "137451"
-                        }
-                    ], 
-                    "Package": "wheel"
-                }, 
-                {
-                    "Info1": [
-                        {
-                            "Version": "2.0.0", 
-                            "Size": "504226"
-                        }
-                    ], 
-                    "Info2": [
-                        {
-                            "Version": "0.8.0", 
-                            "Size": "73348"
-                        }
-                    ], 
-                    "Package": "mock"
-                }
-            ]
-        }
+      },
+      "InfoDiff": []
     }
+  },
+  {
+    "Image1": "gcr.io/gcp-runtimes/multi-base",
+    "Image2": "gcr.io/gcp-runtimes/multi-modified",
+    "DiffType": "Node",
+    "Diff": {
+      "Packages1": {},
+      "Packages2": {
+        "pax": {
+          "/node_modules/pax/": {
+            "Version": "0.2.1",
+            "Size": 11998
+          }
+        }
+      },
+      "InfoDiff": [
+        {
+          "Package": "sax",
+          "Info1": [
+            {
+              "Version": "1.2.4",
+              "Size": 56382
+            }
+          ],
+          "Info2": [
+            {
+              "Version": "0.1.1",
+              "Size": 127107
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "Image1": "gcr.io/gcp-runtimes/multi-base",
+    "Image2": "gcr.io/gcp-runtimes/multi-modified",
+    "DiffType": "Pip",
+    "Diff": {
+      "Packages1": {
+        "pbr": {
+          "/usr/local/lib/python3.6/site-packages": {
+            "Version": "3.1.1",
+            "Size": 447110
+          }
+        }
+      },
+      "Packages2": {
+        "retrying": {
+          "/usr/local/lib/python3.6/site-packages": {
+            "Version": "1.3.3",
+            "Size": 9955
+          }
+        }
+      },
+      "InfoDiff": [
+        {
+          "Package": "mock",
+          "Info1": [
+            {
+              "Version": "2.0.0",
+              "Size": 504226
+            }
+          ],
+          "Info2": [
+            {
+              "Version": "0.8.0",
+              "Size": 73348
+            }
+          ]
+        },
+        {
+          "Package": "setuptools",
+          "Info1": [
+            {
+              "Version": "36.2.2",
+              "Size": 839895
+            }
+          ],
+          "Info2": [
+            {
+              "Version": "36.2.2",
+              "Size": 1157078
+            }
+          ]
+        },
+        {
+          "Package": "wheel",
+          "Info1": [
+            {
+              "Version": "0.29.0",
+              "Size": 103509
+            }
+          ],
+          "Info2": [
+            {
+              "Version": "0.29.0",
+              "Size": 137451
+            }
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/tests/node_analysis_expected.json
+++ b/tests/node_analysis_expected.json
@@ -6,19 +6,19 @@
       "npm": {
         "/usr/local/lib/node_modules/npm/": {
           "Version": "5.0.3",
-          "Size": "13830218"
+          "Size": 13830218
         }
       },
       "pax": {
         "/node_modules/pax/": {
           "Version": "0.2.1",
-          "Size": "11365"
+          "Size": 11365
         }
       },
       "sax": {
         "/node_modules/sax/": {
           "Version": "0.1.1",
-          "Size": "127390"
+          "Size": 127390
         }
       }
     }

--- a/tests/node_diff_order_expected.json
+++ b/tests/node_diff_order_expected.json
@@ -9,7 +9,7 @@
         "pax": {
           "/node_modules/pax/": {
             "Version": "0.2.1",
-            "Size": "11365"
+            "Size": 11365
           }
         }
       },

--- a/tests/pip_analysis_expected.json
+++ b/tests/pip_analysis_expected.json
@@ -6,37 +6,37 @@
       "mock": {
         "/usr/local/lib/python3.6/site-packages": {
           "Version": "2.0.0",
-          "Size": "504226"
+          "Size": 504226
         }
       },
       "pbr": {
         "/usr/local/lib/python3.6/site-packages": {
           "Version": "3.1.1",
-          "Size": "447110"
+          "Size": 447110
         }
       },
       "pip": {
         "/usr/local/lib/python3.6/site-packages": {
           "Version": "9.0.1",
-          "Size": "5289421"
+          "Size": 5289421
         }
       },
       "setuptools": {
         "/usr/local/lib/python3.6/site-packages": {
           "Version": "36.0.1",
-          "Size": "837337"
+          "Size": 837337
         }
       },
       "six": {
         "/usr/local/lib/python3.6/site-packages": {
           "Version": "1.10.0",
-          "Size": "30098"
+          "Size": 30098
         }
       },
       "wheel": {
         "/usr/local/lib/python3.6/site-packages": {
           "Version": "0.29.0",
-          "Size": "103509"
+          "Size": 103509
         }
       }
     }

--- a/utils/format_utils.go
+++ b/utils/format_utils.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"html/template"
 	"os"
-	"reflect"
 	"strings"
 	"text/tabwriter"
 
@@ -14,14 +13,14 @@ import (
 )
 
 var templates = map[string]string{
-	"utils.SingleVersionPackageDiffResult":    SingleVersionDiffOutput,
-	"utils.MultiVersionPackageDiffResult":     MultiVersionDiffOutput,
-	"utils.HistDiffResult":                    HistoryDiffOutput,
-	"utils.DirDiffResult":                     FSDiffOutput,
-	"utils.ListAnalyzeResult":                 ListAnalysisOutput,
-	"utils.FileAnalyzeResult":                 FileAnalysisOutput,
-	"utils.MultiVersionPackageAnalyzeResult":  MultiVersionPackageOutput,
-	"utils.SingleVersionPackageAnalyzeResult": SingleVersionPackageOutput,
+	"SingleVersionPackageDiff":    SingleVersionDiffOutput,
+	"MultiVersionPackageDiff":     MultiVersionDiffOutput,
+	"HistDiff":                    HistoryDiffOutput,
+	"DirDiff":                     FSDiffOutput,
+	"ListAnalyze":                 ListAnalysisOutput,
+	"FileAnalyze":                 FileAnalysisOutput,
+	"MultiVersionPackageAnalyze":  MultiVersionPackageOutput,
+	"SingleVersionPackageAnalyze": SingleVersionPackageOutput,
 }
 
 func JSONify(diff interface{}) error {
@@ -35,16 +34,15 @@ func JSONify(diff interface{}) error {
 	return nil
 }
 
-func getTemplate(diff interface{}) (string, error) {
-	diffType := reflect.TypeOf(diff).String()
-	if template, ok := templates[diffType]; ok {
+func getTemplate(templateType string) (string, error) {
+	if template, ok := templates[templateType]; ok {
 		return template, nil
 	}
 	return "", errors.New("No available template")
 }
 
-func TemplateOutput(diff interface{}) error {
-	outputTmpl, err := getTemplate(diff)
+func TemplateOutput(diff interface{}, templateType string) error {
+	outputTmpl, err := getTemplate(templateType)
 	if err != nil {
 		glog.Error(err)
 

--- a/utils/package_diff_utils.go
+++ b/utils/package_diff_utils.go
@@ -40,7 +40,7 @@ type Info struct {
 // PackageInfo stores the specific metadata about a package.
 type PackageInfo struct {
 	Version string
-	Size    string
+	Size    int64
 }
 
 func multiVersionDiff(infoDiff []MultiVersionInfo, packageName string, map1, map2 map[string]PackageInfo) []MultiVersionInfo {

--- a/utils/package_diff_utils_test.go
+++ b/utils/package_diff_utils_test.go
@@ -34,46 +34,46 @@ func TestDiffMaps(t *testing.T) {
 		{
 			descrip: "Missing Packages.",
 			map1: map[string]PackageInfo{
-				"pac1": {"1.0", "40"},
-				"pac3": {"3.0", "60"}},
+				"pac1": {"1.0", 40},
+				"pac3": {"3.0", 60}},
 			map2: map[string]PackageInfo{
-				"pac4": {"4.0", "70"},
-				"pac5": {"5.0", "80"}},
+				"pac4": {"4.0", 70},
+				"pac5": {"5.0", 80}},
 			expected: PackageDiff{
 				Packages1: map[string]PackageInfo{
-					"pac1": {"1.0", "40"},
-					"pac3": {"3.0", "60"}},
+					"pac1": {"1.0", 40},
+					"pac3": {"3.0", 60}},
 				Packages2: map[string]PackageInfo{
-					"pac4": {"4.0", "70"},
-					"pac5": {"5.0", "80"}},
+					"pac4": {"4.0", 70},
+					"pac5": {"5.0", 80}},
 				InfoDiff: []Info{}},
 		},
 		{
 			descrip: "Different Versions and Sizes.",
 			map1: map[string]PackageInfo{
-				"pac2": {"2.0", "50"},
-				"pac3": {"3.0", "60"}},
+				"pac2": {"2.0", 50},
+				"pac3": {"3.0", 60}},
 			map2: map[string]PackageInfo{
-				"pac2": {"2.0", "45"},
-				"pac3": {"4.0", "60"}},
+				"pac2": {"2.0", 45},
+				"pac3": {"4.0", 60}},
 			expected: PackageDiff{
 				Packages1: map[string]PackageInfo{},
 				Packages2: map[string]PackageInfo{},
 				InfoDiff: []Info{
-					{"pac2", PackageInfo{"2.0", "50"}, PackageInfo{"2.0", "45"}},
-					{"pac3", PackageInfo{"3.0", "60"}, PackageInfo{"4.0", "60"}}},
+					{"pac2", PackageInfo{"2.0", 50}, PackageInfo{"2.0", 45}},
+					{"pac3", PackageInfo{"3.0", 60}, PackageInfo{"4.0", 60}}},
 			},
 		},
 		{
 			descrip: "Identical packages, versions, and sizes",
 			map1: map[string]PackageInfo{
-				"pac1": {"1.0", "40"},
-				"pac2": {"2.0", "50"},
-				"pac3": {"3.0", "60"}},
+				"pac1": {"1.0", 40},
+				"pac2": {"2.0", 50},
+				"pac3": {"3.0", 60}},
 			map2: map[string]PackageInfo{
-				"pac1": {"1.0", "40"},
-				"pac2": {"2.0", "50"},
-				"pac3": {"3.0", "60"}},
+				"pac1": {"1.0", 40},
+				"pac2": {"2.0", 50},
+				"pac3": {"3.0", 60}},
 			expected: PackageDiff{
 				Packages1: map[string]PackageInfo{},
 				Packages2: map[string]PackageInfo{},
@@ -82,13 +82,13 @@ func TestDiffMaps(t *testing.T) {
 		{
 			descrip: "MultiVersion call with identical Packages in different layers",
 			map1: map[string]map[string]PackageInfo{
-				"pac5": {"globalPath": {"version", "size"}},
-				"pac3": {"notquite/localPath": {"version", "size"}},
-				"pac4": {"globalPath": {"version", "size"}}},
+				"pac5": {"globalPath": {"version", 0}},
+				"pac3": {"notquite/localPath": {"version", 0}},
+				"pac4": {"globalPath": {"version", 0}}},
 			map2: map[string]map[string]PackageInfo{
-				"pac5": {"globalPath": {"version", "size"}},
-				"pac3": {"notquite/localPath": {"version", "size"}},
-				"pac4": {"globalPath": {"version", "size"}}},
+				"pac5": {"globalPath": {"version", 0}},
+				"pac3": {"notquite/localPath": {"version", 0}},
+				"pac4": {"globalPath": {"version", 0}}},
 			expected: MultiVersionPackageDiff{
 				Packages1: map[string]map[string]PackageInfo{},
 				Packages2: map[string]map[string]PackageInfo{},
@@ -98,33 +98,33 @@ func TestDiffMaps(t *testing.T) {
 		{
 			descrip: "MultiVersion Packages",
 			map1: map[string]map[string]PackageInfo{
-				"pac5": {"onlyImg1": {"version", "size"}},
-				"pac4": {"samePlace": {"version", "size"}},
-				"pac1": {"node_modules/pac1": {"1.0", "40"}},
-				"pac2": {"usr/local/lib/node_modules/pac2": {"2.0", "50"},
-					"node_modules/pac2": {"3.0", "50"}}},
+				"pac5": {"onlyImg1": {"version", 0}},
+				"pac4": {"samePlace": {"version", 0}},
+				"pac1": {"node_modules/pac1": {"1.0", 40}},
+				"pac2": {"usr/local/lib/node_modules/pac2": {"2.0", 50},
+					"node_modules/pac2": {"3.0", 50}}},
 			map2: map[string]map[string]PackageInfo{
-				"pac4": {"samePlace": {"version", "size"}},
-				"pac1": {"node_modules/pac1": {"2.0", "40"}},
-				"pac2": {"usr/local/lib/node_modules/pac2": {"4.0", "50"}},
-				"pac3": {"usr/local/lib/node_modules/pac3": {"5.0", "100"}}},
+				"pac4": {"samePlace": {"version", 0}},
+				"pac1": {"node_modules/pac1": {"2.0", 40}},
+				"pac2": {"usr/local/lib/node_modules/pac2": {"4.0", 50}},
+				"pac3": {"usr/local/lib/node_modules/pac3": {"5.0", 100}}},
 			expected: MultiVersionPackageDiff{
 				Packages1: map[string]map[string]PackageInfo{
-					"pac5": {"onlyImg1": {"version", "size"}},
+					"pac5": {"onlyImg1": {"version", 0}},
 				},
 				Packages2: map[string]map[string]PackageInfo{
-					"pac3": {"usr/local/lib/node_modules/pac3": {"5.0", "100"}},
+					"pac3": {"usr/local/lib/node_modules/pac3": {"5.0", 100}},
 				},
 				InfoDiff: []MultiVersionInfo{
 					{
 						Package: "pac1",
-						Info1:   []PackageInfo{{"1.0", "40"}},
-						Info2:   []PackageInfo{{"2.0", "40"}},
+						Info1:   []PackageInfo{{"1.0", 40}},
+						Info2:   []PackageInfo{{"2.0", 40}},
 					},
 					{
 						Package: "pac2",
-						Info1:   []PackageInfo{{"2.0", "50"}, {"3.0", "50"}},
-						Info2:   []PackageInfo{{"4.0", "50"}},
+						Info1:   []PackageInfo{{"2.0", 50}, {"3.0", 50}},
+						Info2:   []PackageInfo{{"4.0", 50}},
 					},
 				},
 			},

--- a/utils/template_utils.go
+++ b/utils/template_utils.go
@@ -20,26 +20,28 @@ const SingleVersionDiffOutput = `
 -----{{.DiffType}}-----
 
 Packages found only in {{.Image1}}:{{if not .Diff.Packages1}} None{{else}}
-NAME	VERSION	SIZE{{range $name, $value := .Diff.Packages1}}{{"\n"}}{{print "-"}}{{$name}}	{{$value.Version}}	{{$value.Size}}B{{end}}{{end}}
+NAME	VERSION	SIZE{{range $name, $value := .Diff.Packages1}}{{"\n"}}{{print "-"}}{{$name}}	{{$value.Version}}	{{$value.Size}}{{end}}{{end}}
 
 Packages found only in {{.Image2}}:{{if not .Diff.Packages2}} None{{else}}
-NAME	VERSION	SIZE{{range $name, $value := .Diff.Packages2}}{{"\n"}}{{print "-"}}{{$name}}	{{$value.Version}}	{{$value.Size}}B{{end}}{{end}}
+NAME	VERSION	SIZE{{range $name, $value := .Diff.Packages2}}{{"\n"}}{{print "-"}}{{$name}}	{{$value.Version}}	{{$value.Size}}{{end}}{{end}}
 
 Version differences:{{if not .Diff.InfoDiff}} None{{else}}
-PACKAGE	IMAGE1 ({{.Image1}})	IMAGE2 ({{.Image2}}){{range .Diff.InfoDiff}}{{"\n"}}{{print "-"}}{{.Package}}	{{.Info1.Version}}, {{.Info1.Size}}B	{{.Info2.Version}}, {{.Info2.Size}}B{{end}}{{end}}
+PACKAGE	IMAGE1 ({{.Image1}})	IMAGE2 ({{.Image2}}){{range .Diff.InfoDiff}}{{"\n"}}{{print "-"}}{{.Package}}	{{.Info1.Version}}, {{.Info1.Size}}	{{.Info2.Version}}, {{.Info2.Size}}{{end}}
+{{end}}
 `
 
 const MultiVersionDiffOutput = `
 -----{{.DiffType}}-----
 
 Packages found only in {{.Image1}}:{{if not .Diff.Packages1}} None{{else}}
-NAME	VERSION	SIZE{{range $name, $value := .Diff.Packages1}}{{"\n"}}{{print "-"}}{{$name}}	{{range $key, $info := $value}}{{$info.Version}}	{{$info.Size}}B{{end}}{{end}}{{end}}
+NAME	VERSION	SIZE{{range $name, $value := .Diff.Packages1}}{{"\n"}}{{print "-"}}{{$name}}	{{range $key, $info := $value}}{{$info.Version}}	{{$info.Size}}{{end}}{{end}}{{end}}
 
 Packages found only in {{.Image2}}:{{if not .Diff.Packages2}} None{{else}}
-NAME	VERSION	SIZE{{range $name, $value := .Diff.Packages2}}{{"\n"}}{{print "-"}}{{$name}}	{{range $key, $info := $value}}{{$info.Version}}	{{$info.Size}}B{{end}}{{end}}{{end}}
+NAME	VERSION	SIZE{{range $name, $value := .Diff.Packages2}}{{"\n"}}{{print "-"}}{{$name}}	{{range $key, $info := $value}}{{$info.Version}}	{{$info.Size}}{{end}}{{end}}{{end}}
 
 Version differences:{{if not .Diff.InfoDiff}} None{{else}}
-PACKAGE	IMAGE1 ({{.Image1}})	IMAGE2 ({{.Image2}}){{range .Diff.InfoDiff}}{{"\n"}}{{print "-"}}{{.Package}}	{{range .Info1}}{{.Version}}, {{.Size}}B{{end}}	{{range .Info2}}{{.Version}}, {{.Size}}B{{end}}{{end}}{{end}}
+PACKAGE	IMAGE1 ({{.Image1}})	IMAGE2 ({{.Image2}}){{range .Diff.InfoDiff}}{{"\n"}}{{print "-"}}{{.Package}}	{{range .Info1}}{{.Version}}, {{.Size}}{{end}}	{{range .Info2}}{{.Version}}, {{.Size}}{{end}}{{end}}
+{{end}}
 `
 
 const HistoryDiffOutput = `
@@ -68,12 +70,12 @@ const MultiVersionPackageOutput = `
 -----{{.AnalyzeType}}-----
 
 Packages found in {{.Image}}:{{if not .Analysis}} None{{else}}
-NAME	VERSION	SIZE{{range $name, $value := .Analysis}}{{"\n"}}{{print "-"}}{{$name}}	{{range $key, $info := $value}}{{$info.Version}}	{{$info.Size}}B{{end}}{{end}}{{end}}
+NAME	VERSION	SIZE{{range $name, $value := .Analysis}}{{"\n"}}{{print "-"}}{{$name}}	{{range $key, $info := $value}}{{$info.Version}}	{{$info.Size}}{{end}}{{end}}{{end}}
 `
 
 const SingleVersionPackageOutput = `
 -----{{.AnalyzeType}}-----
 
 Packages found in {{.Image}}:{{if not .Analysis}} None{{else}}
-NAME	VERSION	SIZE{{range $name, $value := .Analysis}}{{"\n"}}{{print "-"}}{{$name}}	{{$value.Version}}	{{$value.Size}}B{{end}}{{end}}
+NAME	VERSION	SIZE{{range $name, $value := .Analysis}}{{"\n"}}{{print "-"}}{{$name}}	{{$value.Version}}	{{$value.Size}}{{end}}{{end}}
 `


### PR DESCRIPTION
fixes #31 

Previously, all the size fields were strings representing bytes, but I thought it'd be better to leave them as ints in case any numerical analysis ever needed to be performed on them...  Also, now I use the bytefmt library to be able to output those ints as B, MB, KB, etc. strings for the human-readable output instead of just bytes.

@nkubala @aaron-prindle 