### PR TITLE
Removing deferral of file closing during layer untarring

### DIFF
--- a/utils/tar_utils.go
+++ b/utils/tar_utils.go
@@ -56,11 +56,11 @@ func unpackTar(tr *tar.Reader, path string) error {
 			if err != nil {
 				return err
 			}
-			defer currFile.Close()
 			_, err = io.Copy(currFile, tr)
 			if err != nil {
 				return err
 			}
+			currFile.Close()
 		}
 
 	}


### PR DESCRIPTION
I believe this should address the "too many open files" error seen in #33 by closing files right after they are copied into the final image from the tarball instead of waiting until all the files are done being copied.

@aaron-prindle @nkubala 