### PR TITLE
Fixing package diff check

### DIFF
--- a/tests/multi_diff_expected.json
+++ b/tests/multi_diff_expected.json
@@ -115,36 +115,6 @@
               "Size": 73348
             }
           ]
-        },
-        {
-          "Package": "setuptools",
-          "Info1": [
-            {
-              "Version": "36.2.2",
-              "Size": 839895
-            }
-          ],
-          "Info2": [
-            {
-              "Version": "36.2.2",
-              "Size": 1157078
-            }
-          ]
-        },
-        {
-          "Package": "wheel",
-          "Info1": [
-            {
-              "Version": "0.29.0",
-              "Size": 103509
-            }
-          ],
-          "Info2": [
-            {
-              "Version": "0.29.0",
-              "Size": 137451
-            }
-          ]
         }
       ]
     }

--- a/utils/package_diff_utils_test.go
+++ b/utils/package_diff_utils_test.go
@@ -60,7 +60,6 @@ func TestDiffMaps(t *testing.T) {
 				Packages1: map[string]PackageInfo{},
 				Packages2: map[string]PackageInfo{},
 				InfoDiff: []Info{
-					{"pac2", PackageInfo{"2.0", 50}, PackageInfo{"2.0", 45}},
 					{"pac3", PackageInfo{"3.0", 60}, PackageInfo{"4.0", 60}}},
 			},
 		},
@@ -141,7 +140,7 @@ func TestDiffMaps(t *testing.T) {
 			sort.Sort(ByPackage(expected.InfoDiff))
 			sort.Sort(ByPackage(actual.InfoDiff))
 			if !reflect.DeepEqual(expected, actual) {
-				t.Errorf("expected Diff to be: %s but got:%s", expected, actual)
+				t.Errorf("expected Diff to be: %v but got:%v", expected, actual)
 				return
 			}
 		case MultiVersionPackageDiff:
@@ -158,7 +157,7 @@ func TestDiffMaps(t *testing.T) {
 				sort.Sort(ByPackageInfo(pack2.Info2))
 			}
 			if !reflect.DeepEqual(expected, actual) {
-				t.Errorf("expected Diff to be: %s but got:%s", expected, actual)
+				t.Errorf("expected Diff to be: %v but got:%v", expected, actual)
 				return
 			}
 		}


### PR DESCRIPTION
Previously, package structs were compared via a DeepEqual, but that was counting packages as different when their size was different (due to caching files, etc. that had changed) even if their versions were the same.  So, under the assumption that non-negligible package content changes would be indicated by a version change, I changed the equality of packages to only consider version differences and not size differences.
@aaron-prindle @nkubala  