### PR TITLE
Remove fake sourceCtx

### DIFF
--- a/utils/image_prep_utils.go
+++ b/utils/image_prep_utils.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/containers/image/docker"
 	"github.com/containers/image/docker/tarfile"
-	"github.com/containers/image/types"
 	"github.com/docker/docker/client"
 
 	"github.com/golang/glog"
@@ -134,23 +133,14 @@ func (p CloudPrepper) getFileSystem() (string, error) {
 		return "", err
 	}
 
-	// By default, the image library will try to look at /etc/docker/certs.d
-	// As a non-root user, this would result in a permissions error, so we avoid this
-	// by looking in a temporary directory we create in the container-diff home directory
-	cwd, _ := os.Getwd()
-	tmpCerts, _ := ioutil.TempDir(cwd, "certs")
-	defer os.RemoveAll(tmpCerts)
-	ctx := &types.SystemContext{
-		DockerCertPath: tmpCerts,
-	}
-	img, err := ref.NewImage(ctx)
+	img, err := ref.NewImage(nil)
 	if err != nil {
 		glog.Error(err)
 		return "", err
 	}
 	defer img.Close()
 
-	imgSrc, err := ref.NewImageSource(ctx, nil)
+	imgSrc, err := ref.NewImageSource(nil, nil)
 	if err != nil {
 		glog.Error(err)
 		return "", err
@@ -184,16 +174,7 @@ func (p CloudPrepper) getConfig() (ConfigSchema, error) {
 		return ConfigSchema{}, err
 	}
 
-	// By default, the image library will try to look at /etc/docker/certs.d
-	// As a non-root user, this would result in a permissions error, so we avoid this
-	// by looking in a temporary directory we create in the container-diff home directory
-	cwd, _ := os.Getwd()
-	tmpCerts, _ := ioutil.TempDir(cwd, "certs")
-	defer os.RemoveAll(tmpCerts)
-	ctx := &types.SystemContext{
-		DockerCertPath: tmpCerts,
-	}
-	img, err := ref.NewImage(ctx)
+	img, err := ref.NewImage(nil)
 	if err != nil {
 		glog.Errorf("Error referencing image %s from registry: %s", p.Source, err)
 		return ConfigSchema{}, errors.New("Could not obtain image config")


### PR DESCRIPTION
The containers/image library has been updated to not throw a fatal
error when it can't read /etc/docker/certs.d