### PR TITLE
Run tests in parallel, dont use working dir

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -94,8 +94,7 @@ func analyzeImage(imageArg string, analyzerArgs []string) error {
 	outputResults(analyses)
 
 	if save {
-		dir, _ := os.Getwd()
-		glog.Infof("Image was saved at %s as %s", dir, image.FSPath)
+		glog.Infof("Image was saved at %s", image.FSPath)
 	}
 
 	return nil

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -110,8 +110,7 @@ func diffImages(image1Arg, image2Arg string, diffArgs []string) error {
 	outputResults(diffs)
 
 	if save {
-		dir, _ := os.Getwd()
-		glog.Infof("Images were saved at %s as %s and %s", dir, imageMap[image1Arg].FSPath,
+		glog.Infof("Images were saved at %s and %s", imageMap[image1Arg].FSPath,
 			imageMap[image2Arg].FSPath)
 
 	}

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -162,6 +162,7 @@ func TestDiffAndAnalysis(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
+			t.Parallel()
 			args := []string{test.subcommand, test.imageA}
 			if test.imageB != "" {
 				args = append(args, test.imageB)

--- a/utils/image_prep_utils.go
+++ b/utils/image_prep_utils.go
@@ -128,7 +128,13 @@ func (p CloudPrepper) getFileSystem() (string, error) {
 	URLPattern := regexp.MustCompile("^.+/(.+(:.+){0,1})$")
 	URLMatch := URLPattern.FindStringSubmatch(p.Source)
 	// Removing the ":" so that the image path name can be <image><tag>
-	path := strings.Replace(URLMatch[1], ":", "", -1)
+	sanitizedName := strings.Replace(URLMatch[1], ":", "", -1)
+
+	path, err := ioutil.TempDir("", sanitizedName)
+	if err != nil {
+		return "", err
+	}
+
 	ref, err := docker.ParseReference("//" + p.Source)
 	if err != nil {
 		return "", err
@@ -154,10 +160,6 @@ func (p CloudPrepper) getFileSystem() (string, error) {
 	if err != nil {
 		glog.Error(err)
 		return "", err
-	}
-
-	if _, ok := os.Stat(path); ok != nil {
-		os.MkdirAll(path, 0777)
 	}
 
 	for _, b := range img.LayerInfos() {


### PR DESCRIPTION
This changes the CloudPrepper to not store intermediate artifacts in
the current directory, allowing the tests to be ran in parallel.