### PR TITLE
Unpack tars into tempdirs.

### DIFF
--- a/pkg/util/image_prep_utils.go
+++ b/pkg/util/image_prep_utils.go
@@ -20,10 +20,8 @@ import (
 	"archive/tar"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/containers/image/pkg/compression"
@@ -76,14 +74,15 @@ func getImage(p Prepper) (Image, error) {
 		FSPath: imgPath,
 		Config: config,
 	}, nil
-	return Image{}, fmt.Errorf("Could not retrieve image %s from source", p.GetSource())
 }
 
 func getImageFromTar(tarPath string) (string, error) {
 	glog.Info("Extracting image tar to obtain image file system")
-	path := strings.TrimSuffix(tarPath, filepath.Ext(tarPath))
-	err := unpackDockerSave(tarPath, path)
-	return path, err
+	tempPath, err := ioutil.TempDir("", ".container-diff")
+	if err != nil {
+		return "", err
+	}
+	return tempPath, unpackDockerSave(tarPath, tempPath)
 }
 
 func getFileSystemFromReference(ref types.ImageReference, imageName string) (string, error) {

--- a/pkg/util/tar_prepper.go
+++ b/pkg/util/tar_prepper.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/containers/image/docker/tarfile"
 	"github.com/docker/docker/client"
@@ -51,10 +50,12 @@ func (p TarPrepper) GetFileSystem() (string, error) {
 }
 
 func (p TarPrepper) GetConfig() (ConfigSchema, error) {
-	tempDir := strings.TrimSuffix(p.Source, filepath.Ext(p.Source)) + "-config"
-	defer os.RemoveAll(tempDir)
-	err := UnTar(p.Source, tempDir)
+	tempDir, err := ioutil.TempDir("", ".container-diff")
 	if err != nil {
+		return ConfigSchema{}, nil
+	}
+	defer os.RemoveAll(tempDir)
+	if err := UnTar(p.Source, tempDir); err != nil {
 		return ConfigSchema{}, err
 	}
 


### PR DESCRIPTION
This fixes container-diff when running in the bazel-bin directory.