### PR TITLE
add layer caching

### DIFF
--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//differs:go_default_library",
+        "//pkg/cache:go_default_library",
         "//pkg/util:go_default_library",
         "//util:go_default_library",
         "//vendor/github.com/docker/docker/client:go_default_library",

--- a/pkg/cache/BUILD.bazel
+++ b/pkg/cache/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "cache.go",
+        "file_cache.go",
+    ],
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/sirupsen/logrus:go_default_library"],
+)

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2017 Google, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import "io"
+
+type Cache interface {
+	HasLayer(string) bool
+	GetLayer(string) (io.ReadCloser, error)
+	SetLayer(string, io.Reader) (io.ReadCloser, error)
+	Invalidate(string) error
+}

--- a/pkg/cache/file_cache.go
+++ b/pkg/cache/file_cache.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2017 Google, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+)
+
+type FileCache struct {
+	RootDir string
+}
+
+func NewFileCache(dir string) (*FileCache, error) {
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, err
+	}
+	return &FileCache{RootDir: dir}, nil
+}
+
+func (c *FileCache) HasLayer(layerId string) bool {
+	_, err := os.Stat(filepath.Join(c.RootDir, layerId))
+	return !os.IsNotExist(err)
+}
+
+func (c *FileCache) SetLayer(layerId string, r io.Reader) (io.ReadCloser, error) {
+	fullpath := filepath.Join(c.RootDir, layerId)
+	entry, err := os.Create(fullpath)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := io.Copy(entry, r); err != nil {
+		return nil, err
+	}
+	return c.GetLayer(layerId)
+}
+
+func (c *FileCache) GetLayer(layerId string) (io.ReadCloser, error) {
+	logrus.Infof("retrieving layer %s from cache", layerId)
+	return os.Open(filepath.Join(c.RootDir, layerId))
+}
+
+func (c *FileCache) Invalidate(layerId string) error {
+	return os.RemoveAll(filepath.Join(c.RootDir, layerId))
+}

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/cache:go_default_library",
         "//vendor/github.com/containers/image/docker:go_default_library",
         "//vendor/github.com/containers/image/docker/daemon:go_default_library",
         "//vendor/github.com/containers/image/docker/tarfile:go_default_library",

--- a/pkg/util/cloud_prepper.go
+++ b/pkg/util/cloud_prepper.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"github.com/GoogleCloudPlatform/container-diff/pkg/cache"
 	"github.com/containers/image/docker"
 	"github.com/docker/docker/client"
 )
@@ -25,6 +26,7 @@ import (
 type CloudPrepper struct {
 	Source string
 	Client *client.Client
+	Cache  cache.Cache
 }
 
 func (p CloudPrepper) Name() string {
@@ -45,7 +47,7 @@ func (p CloudPrepper) GetFileSystem() (string, error) {
 		return "", err
 	}
 
-	return getFileSystemFromReference(ref, p.Source)
+	return getFileSystemFromReference(ref, p.Source, p.Cache)
 }
 
 func (p CloudPrepper) GetConfig() (ConfigSchema, error) {

--- a/pkg/util/daemon_prepper.go
+++ b/pkg/util/daemon_prepper.go
@@ -19,6 +19,7 @@ package util
 import (
 	"context"
 
+	"github.com/GoogleCloudPlatform/container-diff/pkg/cache"
 	"github.com/containers/image/docker/daemon"
 
 	"github.com/docker/docker/client"
@@ -28,6 +29,7 @@ import (
 type DaemonPrepper struct {
 	Source string
 	Client *client.Client
+	Cache  cache.Cache
 }
 
 func (p DaemonPrepper) Name() string {
@@ -47,7 +49,7 @@ func (p DaemonPrepper) GetFileSystem() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return getFileSystemFromReference(ref, p.Source)
+	return getFileSystemFromReference(ref, p.Source, p.Cache)
 }
 
 func (p DaemonPrepper) GetConfig() (ConfigSchema, error) {

--- a/pkg/util/tar_prepper.go
+++ b/pkg/util/tar_prepper.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/GoogleCloudPlatform/container-diff/pkg/cache"
 	"github.com/containers/image/docker/tarfile"
 	"github.com/docker/docker/client"
 	"github.com/sirupsen/logrus"
@@ -31,6 +32,7 @@ import (
 type TarPrepper struct {
 	Source string
 	Client *client.Client
+	Cache  cache.Cache
 }
 
 func (p TarPrepper) Name() string {

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -24,11 +24,15 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "file_cache_test.go",
         "fs_utils_test.go",
         "output_sort_utils_test.go",
         "package_diff_utils_test.go",
         "tar_utils_test.go",
     ],
     library = ":go_default_library",
-    deps = ["//pkg/util:go_default_library"],
+    deps = [
+        "//pkg/cache:go_default_library",
+        "//pkg/util:go_default_library",
+    ],
 )

--- a/util/file_cache_test.go
+++ b/util/file_cache_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2017 Google, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/container-diff/pkg/cache"
+)
+
+var c *cache.FileCache
+
+func TestCacheData(t *testing.T) {
+	data := "this is a test of caching some bytes. this could be any data."
+	cacheAndTest(t, data, "sha256:realdata")
+}
+
+func TestCacheEmpty(t *testing.T) {
+	cacheAndTest(t, "", "sha256:emptydata")
+}
+
+func cacheAndTest(t *testing.T, testStr string, layerId string) {
+	byteArr := []byte(testStr)
+	r := bytes.NewReader(byteArr)
+
+	if c.HasLayer(layerId) {
+		t.Errorf("cache already has test layer %s", layerId)
+	}
+	c.SetLayer(layerId, r)
+
+	if !c.HasLayer(layerId) {
+		t.Errorf("layer %s not successfully cached", layerId)
+	}
+	cachedLayer, err := c.GetLayer(layerId)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	cachedData, err := ioutil.ReadAll(cachedLayer)
+	cachedStr := string(cachedData)
+	if cachedStr != testStr {
+		t.Errorf("cached data %s does not match original: %s", cachedStr, testStr)
+	}
+}
+
+func TestMain(m *testing.M) {
+	var err error
+	cacheDir, err := ioutil.TempDir("", ".cache")
+	if err != nil {
+		fmt.Printf(err.Error())
+		os.Exit(1)
+	}
+	defer os.RemoveAll(cacheDir)
+	c, err = cache.NewFileCache(cacheDir)
+	if err != nil {
+		fmt.Printf(err.Error())
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}

--- a/util/file_cache_test.go
+++ b/util/file_cache_test.go
@@ -26,18 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/container-diff/pkg/cache"
 )
 
-var c *cache.FileCache
-
-func TestCacheData(t *testing.T) {
-	data := "this is a test of caching some bytes. this could be any data."
-	cacheAndTest(t, data, "sha256:realdata")
-}
-
-func TestCacheEmpty(t *testing.T) {
-	cacheAndTest(t, "", "sha256:emptydata")
-}
-
-func cacheAndTest(t *testing.T, testStr string, layerId string) {
+func cacheAndTest(c *cache.FileCache, t *testing.T, testStr string, layerId string) {
 	byteArr := []byte(testStr)
 	r := bytes.NewReader(byteArr)
 
@@ -60,18 +49,29 @@ func cacheAndTest(t *testing.T, testStr string, layerId string) {
 	}
 }
 
-func TestMain(m *testing.M) {
-	var err error
+func TestCache(t *testing.T) {
 	cacheDir, err := ioutil.TempDir("", ".cache")
 	if err != nil {
 		fmt.Printf(err.Error())
 		os.Exit(1)
 	}
 	defer os.RemoveAll(cacheDir)
-	c, err = cache.NewFileCache(cacheDir)
+	c, err := cache.NewFileCache(cacheDir)
 	if err != nil {
 		fmt.Printf(err.Error())
 		os.Exit(1)
 	}
-	os.Exit(m.Run())
+	testRuns := []struct {
+		Name    string
+		Data    string
+		LayerId string
+	}{
+		{"real data", "this is a test of caching some bytes. this could be any data.", "sha256:realdata"},
+		{"empty data", "", "sha256:emptydata"},
+	}
+	for _, test := range testRuns {
+		t.Run(test.Name, func(t *testing.T) {
+			cacheAndTest(c, t, test.Data, test.LayerId)
+		})
+	}
 }

--- a/util/file_cache_test.go
+++ b/util/file_cache_test.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -52,14 +51,12 @@ func cacheAndTest(c *cache.FileCache, t *testing.T, testStr string, layerId stri
 func TestCache(t *testing.T) {
 	cacheDir, err := ioutil.TempDir("", ".cache")
 	if err != nil {
-		fmt.Printf(err.Error())
-		os.Exit(1)
+		t.Fatalf("error when creating cache directory: %s", err.Error())
 	}
 	defer os.RemoveAll(cacheDir)
 	c, err := cache.NewFileCache(cacheDir)
 	if err != nil {
-		fmt.Printf(err.Error())
-		os.Exit(1)
+		t.Fatalf("error when creating cache: %s", err.Error())
 	}
 	testRuns := []struct {
 		Name    string


### PR DESCRIPTION
slightly modified version of https://github.com/GoogleCloudPlatform/container-diff/pull/102

adds support for disabling cache through CLI, and provides interface for adding other cache implementations later on (i.e. in-memory caching)

cc @dlorenc 