### PR TITLE
add image tag as latest if none given

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -145,8 +145,16 @@ func getPrepperForImage(image string) (pkgutil.Prepper, error) {
 		}, nil
 
 	} else if strings.HasPrefix(image, DaemonPrefix) {
+
+		// remove the DaemonPrefix
+		image := strings.Replace(image, DaemonPrefix, "", -1)
+		// see if the image name has tag provided, if not add latest as tag
+		if !strings.Contains(image, ":") {
+			image = image + ":latest"
+		}
+
 		return pkgutil.DaemonPrepper{
-			Source: strings.Replace(image, DaemonPrefix, "", -1),
+			Source: image,
 			Client: cli,
 			Cache:  fsCache,
 		}, nil


### PR DESCRIPTION
Right now if the image is provided with DaemonPrefix and no image tag is
given then the name resolution does not work, so if no image tag given
default to latest.