### PR TITLE
Drop umask to 0 when writing files to disk

### DIFF
--- a/pkg/util/tar_utils.go
+++ b/pkg/util/tar_utils.go
@@ -22,11 +22,16 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/sirupsen/logrus"
 )
 
 func unpackTar(tr *tar.Reader, path string) error {
+	// drop the umask temporarily to 0, so we can create all files with correct permissions
+	// otherwise the default (022) will cause file permission inconsistencies
+	oldMask := syscall.Umask(0)
+	defer syscall.Umask(oldMask)
 	for {
 		header, err := tr.Next()
 		if err == io.EOF {

--- a/pkg/util/tar_utils.go
+++ b/pkg/util/tar_utils.go
@@ -81,8 +81,7 @@ func unpackTar(tr *tar.Reader, path string) error {
 				return err
 			}
 			// manually set permissions on file, since the default umask (022) will interfere
-			err = os.Chmod(target, mode)
-			if err != nil {
+			if err = os.Chmod(target, mode); err != nil {
 				logrus.Errorf("Error updating file permissions on %s", target)
 				return err
 			}


### PR DESCRIPTION
Previously, files were being written from an image to disk with incorrect permissions because of the default umask value (022). Temporarily dropping this to 0 allows the files to get written with their true permissions.