### PR TITLE
Search for Python version also in /usr/lib/python

### DIFF
--- a/differs/pip_diff_test.go
+++ b/differs/pip_diff_test.go
@@ -33,12 +33,12 @@ func TestGetPythonVersion(t *testing.T) {
 		{
 			layerPath:        "testDirs/pipTests/pythonVersionTests/notAFolder",
 			expectedVersions: []string{},
-			err:              true,
+			err:              false,
 		},
 		{
 			layerPath:        "testDirs/pipTests/pythonVersionTests/noLibLayer",
 			expectedVersions: []string{},
-			err:              true,
+			err:              false,
 		},
 		{
 			layerPath:        "testDirs/pipTests/pythonVersionTests/noPythonLayer",


### PR DESCRIPTION
Path to Python is different on deb-based distributions and rpm-based
distributions (e.g. Fedora, CentOS).