### PR TITLE
Add the std. rpm flags for fast queries.

### DIFF
--- a/differs/rpm_diff.go
+++ b/differs/rpm_diff.go
@@ -126,7 +126,7 @@ func rpmDataFromContainer(image pkgutil.Image) (map[string]util.PackageInfo, err
 	}
 
 	contConf := godocker.Config{
-		Cmd:   []string{"rpm", "-qa", "--qf", "%{NAME}\t%{VERSION}\t%{SIZE}\n"},
+		Cmd:   []string{"rpm", "--nodigest", "--nosignature", "-qa", "--qf", "%{NAME}\t%{VERSION}\t%{SIZE}\n"},
 		Image: imageName,
 	}
 


### PR DESCRIPTION
RPM requires flags to tell it not to re-check checksums as you query it, this adds them to the rpm differ.