### PR TITLE
util: simplify error creation

### DIFF
--- a/util/analyze_output_utils.go
+++ b/util/analyze_output_utils.go
@@ -45,7 +45,7 @@ func (r ListAnalyzeResult) OutputText(resultType string) error {
 	analysis, valid := r.Analysis.([]string)
 	if !valid {
 		logrus.Error("Unexpected structure of Analysis.  Should be of type []string")
-		return errors.New(fmt.Sprintf("Could not output %s analysis result", r.AnalyzeType))
+		return fmt.Errorf("Could not output %s analysis result", r.AnalyzeType)
 	}
 	r.Analysis = analysis
 
@@ -58,7 +58,7 @@ func (r MultiVersionPackageAnalyzeResult) OutputStruct() interface{} {
 	analysis, valid := r.Analysis.(map[string]map[string]PackageInfo)
 	if !valid {
 		logrus.Error("Unexpected structure of Analysis.  Should be of type map[string]map[string]PackageInfo")
-		return errors.New(fmt.Sprintf("Could not output %s analysis result", r.AnalyzeType))
+		return fmt.Errorf("Could not output %s analysis result", r.AnalyzeType)
 	}
 	analysisOutput := getMultiVersionPackageOutput(analysis)
 	output := struct {
@@ -77,7 +77,7 @@ func (r MultiVersionPackageAnalyzeResult) OutputText(resultType string) error {
 	analysis, valid := r.Analysis.(map[string]map[string]PackageInfo)
 	if !valid {
 		logrus.Error("Unexpected structure of Analysis.  Should be of type map[string]map[string]PackageInfo")
-		return errors.New(fmt.Sprintf("Could not output %s analysis result", r.AnalyzeType))
+		return fmt.Errorf("Could not output %s analysis result", r.AnalyzeType)
 	}
 	analysisOutput := getMultiVersionPackageOutput(analysis)
 
@@ -100,7 +100,7 @@ func (r SingleVersionPackageAnalyzeResult) OutputStruct() interface{} {
 	analysis, valid := r.Analysis.(map[string]PackageInfo)
 	if !valid {
 		logrus.Error("Unexpected structure of Analysis.  Should be of type map[string]PackageInfo")
-		return errors.New(fmt.Sprintf("Could not output %s analysis result", r.AnalyzeType))
+		return fmt.Errorf("Could not output %s analysis result", r.AnalyzeType)
 	}
 	analysisOutput := getSingleVersionPackageOutput(analysis)
 	output := struct {
@@ -119,7 +119,7 @@ func (r SingleVersionPackageAnalyzeResult) OutputText(diffType string) error {
 	analysis, valid := r.Analysis.(map[string]PackageInfo)
 	if !valid {
 		logrus.Error("Unexpected structure of Analysis.  Should be of type map[string]PackageInfo")
-		return errors.New(fmt.Sprintf("Could not output %s analysis result", r.AnalyzeType))
+		return fmt.Errorf("Could not output %s analysis result", r.AnalyzeType)
 	}
 	analysisOutput := getSingleVersionPackageOutput(analysis)
 

--- a/util/diff_output_utils.go
+++ b/util/diff_output_utils.go
@@ -36,7 +36,7 @@ func (r MultiVersionPackageDiffResult) OutputStruct() interface{} {
 	diff, valid := r.Diff.(MultiVersionPackageDiff)
 	if !valid {
 		logrus.Error("Unexpected structure of Diff.  Should follow the MultiVersionPackageDiff struct")
-		return errors.New(fmt.Sprintf("Could not output %s diff result", r.DiffType))
+		return fmt.Errorf("Could not output %s diff result", r.DiffType)
 	}
 
 	diffOutput := struct {
@@ -56,7 +56,7 @@ func (r MultiVersionPackageDiffResult) OutputText(diffType string) error {
 	diff, valid := r.Diff.(MultiVersionPackageDiff)
 	if !valid {
 		logrus.Error("Unexpected structure of Diff.  Should follow the MultiVersionPackageDiff struct")
-		return errors.New(fmt.Sprintf("Could not output %s diff result", r.DiffType))
+		return fmt.Errorf("Could not output %s diff result", r.DiffType)
 	}
 
 	strPackages1 := stringifyPackages(getMultiVersionPackageOutput(diff.Packages1))
@@ -102,7 +102,7 @@ func (r SingleVersionPackageDiffResult) OutputStruct() interface{} {
 	diff, valid := r.Diff.(PackageDiff)
 	if !valid {
 		logrus.Error("Unexpected structure of Diff.  Should follow the PackageDiff struct")
-		return errors.New(fmt.Sprintf("Could not output %s diff result", r.DiffType))
+		return fmt.Errorf("Could not output %s diff result", r.DiffType)
 	}
 
 	diffOutput := struct {
@@ -122,7 +122,7 @@ func (r SingleVersionPackageDiffResult) OutputText(diffType string) error {
 	diff, valid := r.Diff.(PackageDiff)
 	if !valid {
 		logrus.Error("Unexpected structure of Diff.  Should follow the PackageDiff struct")
-		return errors.New(fmt.Sprintf("Could not output %s diff result", r.DiffType))
+		return fmt.Errorf("Could not output %s diff result", r.DiffType)
 	}
 
 	strPackages1 := stringifyPackages(getSingleVersionPackageOutput(diff.Packages1))


### PR DESCRIPTION
 - use `fmt.Errorf` instead of `errors.New(fmt.Sprintf())`