### PR TITLE
Add a "MutableSource" type that allows for basic image modifications.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -172,7 +172,7 @@ func getPrepperForImage(image string) (pkgutil.Prepper, error) {
 			return nil, err
 		}
 
-		src, err = cache.NewFileCache(cacheDir, ref, src)
+		src, err = cache.NewFileCache(cacheDir, ref)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cache/BUILD.bazel
+++ b/pkg/cache/BUILD.bazel
@@ -6,8 +6,8 @@ go_library(
     importpath = "github.com/GoogleCloudPlatform/container-diff/pkg/cache",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/image:go_default_library",
         "//vendor/github.com/containers/image/types:go_default_library",
-        "//vendor/github.com/opencontainers/go-digest:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/pkg/image/BUILD.bazel
+++ b/pkg/image/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "mutable_source.go",
+        "proxy_types.go",
+    ],
+    importpath = "github.com/GoogleCloudPlatform/container-diff/pkg/image",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/containers/image/manifest:go_default_library",
+        "//vendor/github.com/containers/image/types:go_default_library",
+        "//vendor/github.com/opencontainers/go-digest:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["mutable_source_test.go"],
+    embed = [":go_default_library"],
+    importpath = "github.com/GoogleCloudPlatform/container-diff/pkg/image",
+    deps = [
+        "//vendor/github.com/containers/image/manifest:go_default_library",
+        "//vendor/github.com/containers/image/types:go_default_library",
+        "//vendor/github.com/opencontainers/go-digest:go_default_library",
+    ],
+)

--- a/pkg/image/mutable_source.go
+++ b/pkg/image/mutable_source.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2017 Google, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package image
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"time"
+
+	"github.com/containers/image/manifest"
+	"github.com/containers/image/types"
+	digest "github.com/opencontainers/go-digest"
+)
+
+type MutableSource struct {
+	ProxySource
+	mfst        *manifest.Schema2
+	cfg         *manifest.Schema2Image
+	extraBlobs  map[string][]byte
+	extraLayers []digest.Digest
+}
+
+func NewMutableSource(r types.ImageReference) (*MutableSource, error) {
+	src, err := r.NewImageSource(nil)
+	if err != nil {
+		return nil, err
+	}
+	img, err := r.NewImage(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ms := &MutableSource{
+		ProxySource: ProxySource{
+			Ref:         r,
+			ImageSource: src,
+			img:         img,
+		},
+		extraBlobs: make(map[string][]byte),
+	}
+	if err := ms.populateManifestAndConfig(); err != nil {
+		return nil, err
+	}
+	return ms, nil
+}
+
+// GetManifest marshals the stored manifest to the byte format.
+func (m *MutableSource) GetManifest(_ *digest.Digest) ([]byte, string, error) {
+	s, err := json.Marshal(m.mfst)
+	if err := m.saveConfig(); err != nil {
+		return nil, "", err
+	}
+	return s, manifest.DockerV2Schema2MediaType, err
+}
+
+// populateManifestAndConfig parses the raw manifest and configs, storing them on the struct.
+func (m *MutableSource) populateManifestAndConfig() error {
+	mfstBytes, _, err := m.GetManifest(nil)
+	if err != nil {
+		return err
+	}
+
+	m.mfst, err = manifest.Schema2FromManifest(mfstBytes)
+	if err != nil {
+		return err
+	}
+
+	bi := types.BlobInfo{Digest: m.mfst.ConfigDescriptor.Digest}
+	r, _, err := m.GetBlob(bi)
+	if err != nil {
+		return err
+	}
+
+	cfgBytes, err := ioutil.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(cfgBytes, &m.cfg)
+}
+
+// GetBlob first checks the stored "extra" blobs, then proxies the call to the original source.
+func (m *MutableSource) GetBlob(bi types.BlobInfo) (io.ReadCloser, int64, error) {
+	if b, ok := m.extraBlobs[bi.Digest.String()]; ok {
+		return ioutil.NopCloser(bytes.NewReader(b)), int64(len(b)), nil
+	}
+	return m.ImageSource.GetBlob(bi)
+}
+
+func gzipBytes(b []byte) ([]byte, error) {
+	buf := bytes.NewBuffer([]byte{})
+	w := gzip.NewWriter(buf)
+	_, err := w.Write(b)
+	w.Close()
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// appendLayer appends an uncompressed blob to the image, preserving the invariants required across the config and manifest.
+func (m *MutableSource) appendLayer(content []byte) error {
+	compressedBlob, err := gzipBytes(content)
+	if err != nil {
+		return err
+	}
+
+	dgst := digest.FromBytes(compressedBlob)
+
+	// Add the layer to the manifest.
+	descriptor := manifest.Schema2Descriptor{
+		MediaType: manifest.DockerV2Schema2LayerMediaType,
+		Size:      int64(len(content)),
+		Digest:    dgst,
+	}
+	m.mfst.LayersDescriptors = append(m.mfst.LayersDescriptors, descriptor)
+
+	m.extraBlobs[dgst.String()] = compressedBlob
+	m.extraLayers = append(m.extraLayers, dgst)
+
+	// Also add it to the config.
+	diffID := digest.FromBytes(content)
+	m.cfg.RootFS.DiffIDs = append(m.cfg.RootFS.DiffIDs, diffID)
+	history := manifest.Schema2History{
+		Created: time.Now(),
+		Author:  "container-diff",
+	}
+	m.cfg.History = append(m.cfg.History, history)
+
+	return nil
+}
+
+// saveConfig marshals the stored image config, and updates the references to it in the manifest.
+func (m *MutableSource) saveConfig() error {
+	cfgBlob, err := json.Marshal(m.cfg)
+	if err != nil {
+		return err
+	}
+
+	cfgDigest := digest.FromBytes(cfgBlob)
+	m.extraBlobs[cfgDigest.String()] = cfgBlob
+	m.mfst.ConfigDescriptor = manifest.Schema2Descriptor{
+		MediaType: manifest.DockerV2Schema2ConfigMediaType,
+		Size:      int64(len(cfgBlob)),
+		Digest:    cfgDigest,
+	}
+	return nil
+}

--- a/pkg/image/mutable_source_test.go
+++ b/pkg/image/mutable_source_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2017 Google, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package image
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/containers/image/manifest"
+	"github.com/containers/image/types"
+	digest "github.com/opencontainers/go-digest"
+)
+
+type fields struct {
+	mfst *manifest.Schema2
+	cfg  *manifest.Schema2Image
+}
+type args struct {
+	content string
+}
+
+var testCases = []struct {
+	name    string
+	fields  fields
+	args    args
+	wantErr bool
+}{
+	{
+		name: "add layer",
+		fields: fields{
+			mfst: &manifest.Schema2{
+				LayersDescriptors: []manifest.Schema2Descriptor{
+					{
+						Digest: digest.Digest("abc123"),
+					},
+				},
+			},
+			cfg: &manifest.Schema2Image{
+				RootFS: &manifest.Schema2RootFS{
+					DiffIDs: []digest.Digest{digest.Digest("bcd234")},
+				},
+				History: []manifest.Schema2History{
+					{
+						CreatedBy: "foo",
+					},
+				},
+			},
+		},
+		args: args{
+			content: "myextralayer",
+		},
+		wantErr: false,
+	},
+}
+
+func TestMutableSource_appendLayer(t *testing.T) {
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &MutableSource{
+				mfst:       tt.fields.mfst,
+				cfg:        tt.fields.cfg,
+				extraBlobs: make(map[string][]byte),
+			}
+
+			if err := m.appendLayer([]byte(tt.args.content)); (err != nil) != tt.wantErr {
+				t.Fatalf("MutableSource.appendLayer() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err := m.saveConfig(); err != nil {
+				t.Fatalf("Error saving config: %v", err)
+			}
+			// One blob for the new layer, one for the new config.
+			if len(m.extraBlobs) != 2 {
+				t.Fatal("No extra blob stored after appending layer.")
+			}
+
+			r, _, err := m.GetBlob(types.BlobInfo{Digest: m.mfst.ConfigDescriptor.Digest})
+			if err != nil {
+				t.Fatal("Not able to get new config blob.")
+			}
+
+			cfgBytes, err := ioutil.ReadAll(r)
+			if err != nil {
+				t.Fatal("Unable to read config.")
+			}
+			cfg := manifest.Schema2Image{}
+			if err := json.Unmarshal(cfgBytes, &cfg); err != nil {
+				t.Fatal("Unable to parse config.")
+			}
+
+			if len(cfg.History) != 2 {
+				t.Fatalf("No layer added to image history: %v", cfg.History)
+			}
+
+			if len(cfg.RootFS.DiffIDs) != 2 {
+				t.Fatalf("No layer added to Diff IDs: %v", cfg.RootFS.DiffIDs)
+			}
+			if cfg.RootFS.DiffIDs[1] != digest.FromString(tt.args.content) {
+				t.Fatalf("Incorrect diffid for content. Expected %s, got %s", digest.FromString(tt.args.content), cfg.RootFS.DiffIDs[1])
+			}
+		})
+	}
+}

--- a/pkg/image/proxy_types.go
+++ b/pkg/image/proxy_types.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2017 Google, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package image
+
+import (
+	"github.com/containers/image/types"
+)
+
+// ProxySource is a type that implements types.ImageSource by proxying all calls to an underlying implementation.
+type ProxySource struct {
+	Ref types.ImageReference
+	types.ImageSource
+	img types.Image
+}
+
+func NewProxySource(ref types.ImageReference) (*ProxySource, error) {
+	src, err := ref.NewImageSource(nil)
+	if err != nil {
+		return nil, err
+	}
+	img, err := ref.NewImage(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ProxySource{
+		Ref:         ref,
+		img:         img,
+		ImageSource: src,
+	}, nil
+}
+
+func (p *ProxySource) Reference() types.ImageReference {
+	return p.Ref
+}
+
+func (p *ProxySource) LayerInfosForCopy() []types.BlobInfo {
+	return nil
+}
+
+// ProxyReference implements types.Reference by proxying calls to an underlying implementation.
+type ProxyReference struct {
+	types.ImageReference
+	src types.ImageSource
+}
+
+func (p *ProxyReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
+	return p.src, nil
+}
+
+func (p *ProxyReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
+	return p.ImageReference.NewImageDestination(ctx)
+}


### PR DESCRIPTION
This also introduces a "ProxySource" type, which allows for easier customization.

The main logic in "MutableSource" is in the bookkeeping of changes to the image config and manifest.