### PR TITLE
Save temporary layer in container-diff cache directory instead of /tmp directory

### DIFF
--- a/pkg/cache/file_cache.go
+++ b/pkg/cache/file_cache.go
@@ -57,8 +57,8 @@ func (c *FileCache) HasLayer(layer types.BlobInfo) bool {
 func (c *FileCache) SetLayer(layer types.BlobInfo, r io.Reader) (io.ReadCloser, error) {
 	layerId := layer.Digest.String()
 	fullpath := filepath.Join(c.RootDir, layerId)
-	// Write the entry atomically. First write it to a .tmp name, then rename to the correct one.
-	f, err := ioutil.TempFile("", "")
+	// Write the entry atomically. First write it to a temporary name, then rename to the correct one.
+	f, err := ioutil.TempFile(c.RootDir, "")
 	if err != nil {
 		return nil, err
 	}
@@ -96,6 +96,7 @@ func (c *FileCache) GetBlob(bi types.BlobInfo) (io.ReadCloser, int64, error) {
 	}
 	r, err = c.SetLayer(bi, r)
 	if err != nil {
+		logrus.Errorf("Error setting layer %s in cache: %v", bi.Digest, err)
 		return nil, 0, c.Invalidate(bi)
 	}
 	return r, size, err


### PR DESCRIPTION
I was trying to diff some images built by kbuild, and kept getting this error:

`can't rename /tmp/078692987 to /usr/local/google/home/priyawadhwa/.container-diff/cache/sha256:5482db2bf884077e5eaf85cf0bd062ad71bb69710216ee9e7d9bec98bc4f6984: invalid cross-device link`

The only way I could find to fix it was to save the temporary layer in the same directory, so that the files are on the same device