### PR TITLE
only append latest tag to image once

### DIFF
--- a/boilerplate/boilerplate.py
+++ b/boilerplate/boilerplate.py
@@ -89,7 +89,7 @@ def file_passes(filename, refs, regexs):
         if p.search(d):
             return False
 
-    # Replace all occurrences of the regex "2017|2016|2015|2014" with "YEAR"
+    # Replace all occurrences of the regex "2018|2017|2016|2015|2014" with "YEAR"
     p = regexs["date"]
     for i, d in enumerate(data):
         (data[i], found) = p.subn('YEAR', d)
@@ -149,8 +149,8 @@ def get_regexs():
     regexs = {}
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile( 'YEAR' )
-    # dates can be 2014, 2015, 2016 or 2017, company holder names can be anything
-    regexs["date"] = re.compile( '(2014|2015|2016|2017)' )
+    # dates can be 2014, 2015, 2016, 2017, or 2018, company holder names can be anything
+    regexs["date"] = re.compile( '(2014|2015|2016|2017|2018)' )
     # strip // +build \n\n build constraints
     regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
     # strip #!.* from shell scripts

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -136,7 +136,7 @@ func getPrepperForImage(image string) (pkgutil.Prepper, error) {
 
 	// see if the image name has tag provided, if not add latest as tag
 	if !pkgutil.HasTag(image) {
-		image = image + ":latest"
+		image = image + pkgutil.LatestTag
 	}
 
 	if strings.HasPrefix(image, DaemonPrefix) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -135,28 +135,21 @@ func getPrepperForImage(image string) (pkgutil.Prepper, error) {
 	}
 
 	// see if the image name has tag provided, if not add latest as tag
-	if !strings.Contains(image, ":") {
+	if !pkgutil.HasTag(image) {
 		image = image + ":latest"
 	}
 
 	if strings.HasPrefix(image, DaemonPrefix) {
 		// remove the DaemonPrefix
-		image := strings.Replace(image, DaemonPrefix, "", -1)
-		if !strings.Contains(image, ":") {
-			image = image + ":latest"
-		}
+		image = strings.Replace(image, DaemonPrefix, "", -1)
 
 		return pkgutil.DaemonPrepper{
 			Source: image,
 			Client: cli,
 		}, nil
 	}
-	// either has remote prefix or has no prefix, in which case we force remote
 
-	// see if the image name has tag provided, if not add latest as tag
-	if !strings.Contains(image, ":") {
-		image = image + ":latest"
-	}
+	// either has remote prefix or has no prefix, in which case we force remote
 	ref, err := docker.ParseReference("//" + image)
 	if err != nil {
 		return nil, err

--- a/pkg/util/image_prep_utils.go
+++ b/pkg/util/image_prep_utils.go
@@ -99,7 +99,14 @@ type ConfigSchema struct {
 }
 
 func getImage(p Prepper) (Image, error) {
-	output.PrintToStdErr("Retrieving image %s from source %s\n", p.GetSource(), p.Name())
+	var source string
+	// see if the image name has tag provided, if not add latest as tag
+	if !HasTag(p.GetSource()) {
+		source = p.GetSource() + ":latest"
+	} else {
+		source = p.GetSource()
+	}
+	output.PrintToStdErr("Retrieving image %s from source %s\n", source, p.Name())
 	imgPath, err := p.GetFileSystem()
 	if err != nil {
 		return Image{}, err
@@ -110,9 +117,9 @@ func getImage(p Prepper) (Image, error) {
 		logrus.Error("Error retrieving History: ", err)
 	}
 
-	logrus.Infof("Finished prepping image %s", p.GetSource())
+	logrus.Infof("Finished prepping image %s", source)
 	return Image{
-		Source: p.GetSource(),
+		Source: source,
 		FSPath: imgPath,
 		Config: config,
 	}, nil

--- a/pkg/util/image_prep_utils.go
+++ b/pkg/util/image_prep_utils.go
@@ -102,7 +102,7 @@ func getImage(p Prepper) (Image, error) {
 	var source string
 	// see if the image name has tag provided, if not add latest as tag
 	if !HasTag(p.GetSource()) {
-		source = p.GetSource() + ":latest"
+		source = p.GetSource() + LatestTag
 	} else {
 		source = p.GetSource()
 	}

--- a/pkg/util/image_utils.go
+++ b/pkg/util/image_utils.go
@@ -27,6 +27,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const LatestTag string = ":latest"
+
 func GetImageLayers(pathToImage string) []string {
 	layers := []string{}
 	contents, err := ioutil.ReadDir(pathToImage)
@@ -71,6 +73,6 @@ func copyToFile(outfile string, r io.Reader) error {
 
 // checks to see if an image string contains a tag.
 func HasTag(image string) bool {
-	tagRegex := regexp.MustCompile(".*:[^/]*$")
+	tagRegex := regexp.MustCompile(".*:[^/]+$")
 	return tagRegex.MatchString(image)
 }

--- a/pkg/util/image_utils.go
+++ b/pkg/util/image_utils.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/docker/docker/pkg/system"
 	"github.com/sirupsen/logrus"
@@ -66,4 +67,10 @@ func copyToFile(outfile string, r io.Reader) error {
 	}
 
 	return nil
+}
+
+// checks to see if an image string contains a tag.
+func HasTag(image string) bool {
+	tagRegex := regexp.MustCompile(".*:[^/]*$")
+	return tagRegex.MatchString(image)
 }

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
     srcs = [
         "file_cache_test.go",
         "fs_utils_test.go",
+        "image_utils_test.go",
         "output_sort_utils_test.go",
         "package_diff_utils_test.go",
         "tar_utils_test.go",

--- a/util/image_utils_test.go
+++ b/util/image_utils_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 Google, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	pkgutil "github.com/GoogleCloudPlatform/container-diff/pkg/util"
+)
+
+func TestImageTags(t *testing.T) {
+	tests := []struct {
+		image  string
+		hasTag bool
+	}{
+		{
+			image:  "gcr.io/test_image/foo:latest",
+			hasTag: true,
+		},
+		{
+			image:  "gcr.io/test_image/foo:",
+			hasTag: false,
+		},
+		{
+			image:  "daemon://gcr.io/test_image/foo:test",
+			hasTag: true,
+		},
+		{
+			image:  "remote://gcr.io/test_image_foo",
+			hasTag: false,
+		},
+	}
+
+	for _, test := range tests {
+		if pkgutil.HasTag(test.image) != test.hasTag {
+			t.Errorf("Error checking tag on image %s", test.image)
+		}
+	}
+}


### PR DESCRIPTION
Also, use regex to check if image has tag. Previously, we were just doing a simple `strings.Contains(image, ":")`, which would give us a false positive when checking strings with the `remote://` or `daemon://` prefixes.  This should fix those cases.