### PR TITLE
Only replace image tag when retrieving image, and update source in prepper

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -128,22 +128,17 @@ func getPrepperForImage(image string) (pkgutil.Prepper, error) {
 	}
 
 	if pkgutil.IsTar(image) {
-		return pkgutil.TarPrepper{
+		return &pkgutil.TarPrepper{
 			Source: image,
 			Client: cli,
 		}, nil
-	}
-
-	// see if the image name has tag provided, if not add latest as tag
-	if !pkgutil.HasTag(image) {
-		image = image + pkgutil.LatestTag
 	}
 
 	if strings.HasPrefix(image, DaemonPrefix) {
 		// remove the DaemonPrefix
 		image = strings.Replace(image, DaemonPrefix, "", -1)
 
-		return pkgutil.DaemonPrepper{
+		return &pkgutil.DaemonPrepper{
 			Source: image,
 			Client: cli,
 		}, nil
@@ -171,12 +166,11 @@ func getPrepperForImage(image string) (pkgutil.Prepper, error) {
 		}
 	}
 
-	return pkgutil.CloudPrepper{
+	return &pkgutil.CloudPrepper{
 		Source:      strings.Replace(image, RemotePrefix, "", -1),
 		Client:      cli,
 		ImageSource: src,
 	}, nil
-
 }
 
 func cacheDir() (string, error) {

--- a/pkg/util/cloud_prepper.go
+++ b/pkg/util/cloud_prepper.go
@@ -32,21 +32,25 @@ type CloudPrepper struct {
 	ImageSource types.ImageSource
 }
 
-func (p CloudPrepper) Name() string {
+func (p *CloudPrepper) Name() string {
 	return "Cloud Registry"
 }
 
-func (p CloudPrepper) GetSource() string {
+func (p *CloudPrepper) GetSource() string {
 	return p.Source
 }
 
-func (p CloudPrepper) GetImage() (Image, error) {
+func (p *CloudPrepper) SetSource(source string) {
+	p.Source = source
+}
+
+func (p *CloudPrepper) GetImage() (Image, error) {
 	image, err := getImage(p)
 	image.Type = ImageTypeCloud
 	return image, err
 }
 
-func (p CloudPrepper) GetFileSystem() (string, error) {
+func (p *CloudPrepper) GetFileSystem() (string, error) {
 	ref, err := docker.ParseReference("//" + p.Source)
 	if err != nil {
 		return "", err
@@ -62,7 +66,7 @@ func (p CloudPrepper) GetFileSystem() (string, error) {
 	return path, GetFileSystemFromReference(ref, p.ImageSource, path, nil)
 }
 
-func (p CloudPrepper) GetConfig() (ConfigSchema, error) {
+func (p *CloudPrepper) GetConfig() (ConfigSchema, error) {
 	ref, err := docker.ParseReference("//" + p.Source)
 	if err != nil {
 		return ConfigSchema{}, err

--- a/pkg/util/daemon_prepper.go
+++ b/pkg/util/daemon_prepper.go
@@ -32,21 +32,25 @@ type DaemonPrepper struct {
 	Client *client.Client
 }
 
-func (p DaemonPrepper) Name() string {
+func (p *DaemonPrepper) Name() string {
 	return "Local Daemon"
 }
 
-func (p DaemonPrepper) GetSource() string {
+func (p *DaemonPrepper) GetSource() string {
 	return p.Source
 }
 
-func (p DaemonPrepper) GetImage() (Image, error) {
+func (p *DaemonPrepper) SetSource(source string) {
+	p.Source = source
+}
+
+func (p *DaemonPrepper) GetImage() (Image, error) {
 	image, err := getImage(p)
 	image.Type = ImageTypeDaemon
 	return image, err
 }
 
-func (p DaemonPrepper) GetFileSystem() (string, error) {
+func (p *DaemonPrepper) GetFileSystem() (string, error) {
 	ref, err := daemon.ParseReference(p.Source)
 	if err != nil {
 		return "", err
@@ -67,7 +71,7 @@ func (p DaemonPrepper) GetFileSystem() (string, error) {
 	return path, GetFileSystemFromReference(ref, src, path, nil)
 }
 
-func (p DaemonPrepper) GetConfig() (ConfigSchema, error) {
+func (p *DaemonPrepper) GetConfig() (ConfigSchema, error) {
 	ref, err := daemon.ParseReference(p.Source)
 	if err != nil {
 		return ConfigSchema{}, err
@@ -75,7 +79,7 @@ func (p DaemonPrepper) GetConfig() (ConfigSchema, error) {
 	return getConfigFromReference(ref, p.Source)
 }
 
-func (p DaemonPrepper) GetHistory() []ImageHistoryItem {
+func (p *DaemonPrepper) GetHistory() []ImageHistoryItem {
 	history, err := p.Client.ImageHistory(context.Background(), p.Source)
 	if err != nil {
 		logrus.Errorf("Could not obtain image history for %s: %s", p.Source, err)

--- a/pkg/util/image_prep_utils.go
+++ b/pkg/util/image_prep_utils.go
@@ -38,6 +38,7 @@ type Prepper interface {
 	GetFileSystem() (string, error)
 	GetImage() (Image, error)
 	GetSource() string
+	SetSource(string)
 }
 
 type ImageType int
@@ -99,14 +100,11 @@ type ConfigSchema struct {
 }
 
 func getImage(p Prepper) (Image, error) {
-	var source string
 	// see if the image name has tag provided, if not add latest as tag
 	if !HasTag(p.GetSource()) {
-		source = p.GetSource() + LatestTag
-	} else {
-		source = p.GetSource()
+		p.SetSource(p.GetSource() + LatestTag)
 	}
-	output.PrintToStdErr("Retrieving image %s from source %s\n", source, p.Name())
+	output.PrintToStdErr("Retrieving image %s from source %s\n", p.GetSource(), p.Name())
 	imgPath, err := p.GetFileSystem()
 	if err != nil {
 		return Image{}, err
@@ -117,9 +115,9 @@ func getImage(p Prepper) (Image, error) {
 		logrus.Error("Error retrieving History: ", err)
 	}
 
-	logrus.Infof("Finished prepping image %s", source)
+	logrus.Infof("Finished prepping image %s", p.GetSource())
 	return Image{
-		Source: source,
+		Source: p.GetSource(),
 		FSPath: imgPath,
 		Config: config,
 	}, nil

--- a/pkg/util/tar_prepper.go
+++ b/pkg/util/tar_prepper.go
@@ -32,25 +32,29 @@ type TarPrepper struct {
 	Client *client.Client
 }
 
-func (p TarPrepper) Name() string {
+func (p *TarPrepper) Name() string {
 	return "Tar Archive"
 }
 
-func (p TarPrepper) GetSource() string {
+func (p *TarPrepper) GetSource() string {
 	return p.Source
 }
 
-func (p TarPrepper) GetImage() (Image, error) {
+func (p *TarPrepper) SetSource(source string) {
+	p.Source = source
+}
+
+func (p *TarPrepper) GetImage() (Image, error) {
 	image, err := getImage(p)
 	image.Type = ImageTypeTar
 	return image, err
 }
 
-func (p TarPrepper) GetFileSystem() (string, error) {
+func (p *TarPrepper) GetFileSystem() (string, error) {
 	return getImageFromTar(p.Source)
 }
 
-func (p TarPrepper) GetConfig() (ConfigSchema, error) {
+func (p *TarPrepper) GetConfig() (ConfigSchema, error) {
 	tempDir, err := ioutil.TempDir("", ".container-diff")
 	if err != nil {
 		return ConfigSchema{}, nil


### PR DESCRIPTION
This adds a `SetSource()` method to the preppers, which is used in the call to `getImage()` to update the image source with an appended tag if necessary.

Contains a slight refactor to pass around preppers by reference (rather than by value) so they can be updated appropriately.