### PR TITLE
Create default ImageSource if none is provided

### DIFF
--- a/pkg/util/image_prep_utils.go
+++ b/pkg/util/image_prep_utils.go
@@ -133,6 +133,13 @@ func getImageFromTar(tarPath string) (string, error) {
 }
 
 func GetFileSystemFromReference(ref types.ImageReference, imgSrc types.ImageSource, path string, whitelist []string) error {
+	var err error
+	if imgSrc == nil {
+		imgSrc, err = ref.NewImageSource(nil)
+	}
+	if err != nil {
+		return err
+	}
 	img, err := ref.NewImage(nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
This will allow callers to just pass in the `Source` when creating a `Prepper` struct, e.g.

```
prepper := &CloudPrepper{
  Source: "gcr.io/registry/image",
}
```
and avoid getting a panic when calling `prepper.GetImage()`.