### PR TITLE
Set/unset write bit on unwriteable directories when unpacking tars

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -282,6 +282,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6e818cd6f09d26d5ae0fe9f66a9dd88de47a87a1b4a5048422947f43e7838f9b"
+  inputs-digest = "011f13273effca41fb1b82358a8c8848c419b09bc3f37e07dd7213d3f8836c31"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/differs/BUILD.bazel
+++ b/differs/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "differs.go",
         "file_diff.go",
         "history_diff.go",
+        "metadata_diff.go",
         "node_diff.go",
         "package_differs.go",
         "pip_diff.go",

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//vendor/github.com/containers/image/types:go_default_library",
         "//vendor/github.com/docker/docker/client:go_default_library",
         "//vendor/github.com/docker/docker/pkg/system:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/pkg/util/image_prep_utils.go
+++ b/pkg/util/image_prep_utils.go
@@ -237,7 +237,7 @@ func CleanupImage(image Image) {
 	if image.FSPath != "" {
 		logrus.Infof("Removing image filesystem directory %s from system", image.FSPath)
 		if err := os.RemoveAll(image.FSPath); err != nil {
-			logrus.Error(err.Error())
+			logrus.Warn(err.Error())
 		}
 	}
 }


### PR DESCRIPTION
When unpacking image tars, sometimes we run into directories that were unwriteable in the image. The directories will get created by container-diff, but then any subsequent files being written to the directory will fail. To fix this, we set the world-writable bit on the directory when we create it, then defer resetting the permissions so we can write all of its contents.

Fixes #168 