### PR TITLE
Correctly handle case where no image source is parsed

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -151,10 +151,10 @@ func getPrepperForImage(image string) (pkgutil.Prepper, error) {
 		return nil, err
 	}
 	src, err := ref.NewImageSource(nil)
-	defer src.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer src.Close()
 
 	if !noCache {
 		cacheDir, err := cacheDir()

--- a/pkg/image/proxy_types.go
+++ b/pkg/image/proxy_types.go
@@ -29,10 +29,10 @@ type ProxySource struct {
 
 func NewProxySource(ref types.ImageReference) (*ProxySource, error) {
 	src, err := ref.NewImageSource(nil)
-	defer src.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer src.Close()
 	img, err := ref.NewImage(nil)
 	if err != nil {
 		return nil, err

--- a/pkg/util/daemon_prepper.go
+++ b/pkg/util/daemon_prepper.go
@@ -57,10 +57,10 @@ func (p *DaemonPrepper) GetFileSystem() (string, error) {
 	}
 
 	src, err := ref.NewImageSource(nil)
-	defer src.Close()
 	if err != nil {
 		return "", err
 	}
+	defer src.Close()
 
 	sanitizedName := strings.Replace(p.Source, ":", "", -1)
 	sanitizedName = strings.Replace(sanitizedName, "/", "", -1)

--- a/pkg/util/image_prep_utils.go
+++ b/pkg/util/image_prep_utils.go
@@ -152,11 +152,11 @@ func GetFileSystemFromReference(ref types.ImageReference, imgSrc types.ImageSour
 	var err error
 	if imgSrc == nil {
 		imgSrc, err = ref.NewImageSource(nil)
-		defer imgSrc.Close()
 	}
 	if err != nil {
 		return err
 	}
+	defer imgSrc.Close()
 	img, err := ref.NewImage(nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
This fixes a panic that happens most commonly when a docker ID is passed instead of an image path.